### PR TITLE
Feature/eliminate empty attributes

### DIFF
--- a/samples/event_with_eventdata.json
+++ b/samples/event_with_eventdata.json
@@ -1,0 +1,54 @@
+{
+  "Event": {
+    "#attributes": {
+      "xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"
+    },
+    "EventData": {
+      "CommandLine": "",
+      "MandatoryLabel": "S-1-16-16384",
+      "NewProcessId": "0x58",
+      "NewProcessName": "Registry",
+      "ParentProcessName": "",
+      "ProcessId": "0x4",
+      "SubjectDomainName": "-",
+      "SubjectLogonId": "0x3e7",
+      "SubjectUserName": "-",
+      "SubjectUserSid": "S-1-5-18",
+      "TargetDomainName": "-",
+      "TargetLogonId": "0x0",
+      "TargetUserName": "-",
+      "TargetUserSid": "S-1-0-0",
+      "TokenElevationType": "%%1936"
+    },
+    "System": {
+      "Channel": "Security",
+      "Computer": "WIN-LL0C19JS506",
+      "Correlation": null,
+      "EventID": 4688,
+      "EventRecordID": 1,
+      "Execution": {
+        "#attributes": {
+          "ProcessID": 4,
+          "ThreadID": 32
+        }
+      },
+      "Keywords": "0x8020000000000000",
+      "Level": 0,
+      "Opcode": 0,
+      "Provider": {
+        "#attributes": {
+          "Guid": "54849625-5478-4994-A5BA-3E3B0328C30D",
+          "Name": "Microsoft-Windows-Security-Auditing"
+        }
+      },
+      "Security": null,
+      "Task": 13312,
+      "TimeCreated": {
+        "#attributes": {
+          "SystemTime": "2018-07-28T07:24:45.754787Z"
+        }
+      },
+      "Version": 2
+    }
+  }
+}

--- a/samples/event_with_eventdata.xml
+++ b/samples/event_with_eventdata.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+    <System>
+        <Provider Name="Microsoft-Windows-Security-Auditing" Guid="54849625-5478-4994-A5BA-3E3B0328C30D">
+        </Provider>
+        <EventID>4688</EventID>
+        <Version>2</Version>
+        <Level>0</Level>
+        <Task>13312</Task>
+        <Opcode>0</Opcode>
+        <Keywords>0x8020000000000000</Keywords>
+        <TimeCreated SystemTime="2018-07-28 07:24:45.754787 UTC">
+        </TimeCreated>
+        <EventRecordID>1</EventRecordID>
+        <Correlation>
+        </Correlation>
+        <Execution ProcessID="4" ThreadID="32">
+        </Execution>
+        <Channel>Security</Channel>
+        <Computer>WIN-LL0C19JS506</Computer>
+        <Security>
+        </Security>
+    </System>
+    <EventData>
+        <Data Name="SubjectUserSid">S-1-5-18</Data>
+        <Data Name="SubjectUserName">-</Data>
+        <Data Name="SubjectDomainName">-</Data>
+        <Data Name="SubjectLogonId">0x3e7</Data>
+        <Data Name="NewProcessId">0x58</Data>
+        <Data Name="NewProcessName">Registry</Data>
+        <Data Name="TokenElevationType">%%1936</Data>
+        <Data Name="ProcessId">0x4</Data>
+        <Data Name="CommandLine"></Data>
+        <Data Name="TargetUserSid">S-1-0-0</Data>
+        <Data Name="TargetUserName">-</Data>
+        <Data Name="TargetDomainName">-</Data>
+        <Data Name="TargetLogonId">0x0</Data>
+        <Data Name="ParentProcessName"></Data>
+        <Data Name="MandatoryLabel">S-1-16-16384</Data>
+    </EventData>
+</Event>

--- a/samples/event_with_text_and_attributes.json
+++ b/samples/event_with_text_and_attributes.json
@@ -1,0 +1,38 @@
+{
+  "Event": {
+    "#attributes": {
+      "xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"
+    },
+    "EventData": {
+      "Binary": null,
+      "Data": {
+        "#text": []
+      }
+    },
+    "System": {
+      "Channel": "System",
+      "Computer": "WIN-P4SIAA0SQCO",
+      "EventID": {
+        "#attributes": {
+          "Qualifiers": 32768
+        },
+        "#text": 6009
+      },
+      "EventRecordID": 1,
+      "Keywords": "0x80000000000000",
+      "Level": 4,
+      "Provider": {
+        "#attributes": {
+          "Name": "EventLog"
+        }
+      },
+      "Security": null,
+      "Task": 0,
+      "TimeCreated": {
+        "#attributes": {
+          "SystemTime": "2017-07-12T17:16:28.214161Z"
+        }
+      }
+    }
+  }
+}

--- a/samples/event_with_text_and_attributes.xml
+++ b/samples/event_with_text_and_attributes.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+    <System>
+        <Provider Name="EventLog">
+        </Provider>
+        <EventID Qualifiers="32768">6009</EventID>
+        <Level>4</Level>
+        <Task>0</Task>
+        <Keywords>0x80000000000000</Keywords>
+        <TimeCreated SystemTime="2017-07-12 17:16:28.214161 UTC">
+        </TimeCreated>
+        <EventRecordID>1</EventRecordID>
+        <Channel>System</Channel>
+        <Computer>WIN-P4SIAA0SQCO</Computer>
+        <Security>
+        </Security>
+    </System>
+    <EventData>
+        <Data></Data>
+        <Binary></Binary>
+    </EventData>
+</Event>

--- a/samples/security_event_1.json
+++ b/samples/security_event_1.json
@@ -1,0 +1,38 @@
+{
+  "Event": {
+    "#attributes": {
+      "xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"
+    },
+    "EventData": null,
+    "System": {
+      "Channel": "Security",
+      "Computer": "37L4247F27-25",
+      "Correlation": null,
+      "EventID": 4608,
+      "EventRecordID": 1,
+      "Execution": {
+        "#attributes": {
+          "ProcessID": 456,
+          "ThreadID": 460
+        }
+      },
+      "Keywords": "0x8020000000000000",
+      "Level": 0,
+      "Opcode": 0,
+      "Provider": {
+        "#attributes": {
+          "Guid": "54849625-5478-4994-A5BA-3E3B0328C30D",
+          "Name": "Microsoft-Windows-Security-Auditing"
+        }
+      },
+      "Security": null,
+      "Task": 12288,
+      "TimeCreated": {
+        "#attributes": {
+          "SystemTime": "2016-07-08T18:12:51.681640Z"
+        }
+      },
+      "Version": 0
+    }
+  }
+}

--- a/samples/security_event_1.xml
+++ b/samples/security_event_1.xml
@@ -3,7 +3,7 @@
     <System>
         <Provider Name="Microsoft-Windows-Security-Auditing" Guid="54849625-5478-4994-A5BA-3E3B0328C30D">
         </Provider>
-        <EventID Qualifiers="">4608</EventID>
+        <EventID>4608</EventID>
         <Version>0</Version>
         <Level>0</Level>
         <Task>12288</Task>
@@ -12,13 +12,13 @@
         <TimeCreated SystemTime="2016-07-08 18:12:51.681640 UTC">
         </TimeCreated>
         <EventRecordID>1</EventRecordID>
-        <Correlation ActivityID="" RelatedActivityID="">
+        <Correlation>
         </Correlation>
         <Execution ProcessID="456" ThreadID="460">
         </Execution>
         <Channel>Security</Channel>
         <Computer>37L4247F27-25</Computer>
-        <Security UserID="">
+        <Security>
         </Security>
     </System>
     <EventData>

--- a/src/benches/benchmark.rs
+++ b/src/benches/benchmark.rs
@@ -19,6 +19,19 @@ fn process_90_records(buffer: &'static [u8]) {
     }
 }
 
+fn process_90_records_json(buffer: &'static [u8]) {
+    let mut parser = EvtxParser::from_buffer(buffer.to_vec()).unwrap();
+
+    for (i, record) in parser.records_json().take(90).enumerate() {
+        match record {
+            Ok(r) => {
+                assert_eq!(r.event_record_id, i as u64 + 1);
+            }
+            Err(e) => println!("Error while reading record {}, {:?}", i, e),
+        }
+    }
+}
+
 fn criterion_benchmark(c: &mut Criterion) {
     let evtx_file = include_bytes!("../../samples/security.evtx");
     // ~11ms before strings cache
@@ -26,6 +39,10 @@ fn criterion_benchmark(c: &mut Criterion) {
     // ~8ms with cached templates as well
     c.bench_function("read 90 records", move |b| {
         b.iter(|| process_90_records(evtx_file))
+    });
+
+    c.bench_function("read 90 records json", move |b| {
+        b.iter(|| process_90_records_json(evtx_file))
     });
 }
 

--- a/src/binxml/deserializer.rs
+++ b/src/binxml/deserializer.rs
@@ -287,7 +287,6 @@ impl<'a, 'c> Iterator for IterTokens<'a, 'c> {
 mod tests {
     use crate::ensure_env_logger_initialized;
     use crate::evtx_chunk::EvtxChunkData;
-    use pretty_assertions::assert_eq;
 
     #[test]
     fn test_reads_a_single_record() {
@@ -301,35 +300,6 @@ mod tests {
         for record in records.into_iter().take(1) {
             assert!(record.is_ok(), record.unwrap().into_xml())
         }
-    }
-
-    #[test]
-    fn test_event_xml_text_contains_all_closing_tags() {
-        ensure_env_logger_initialized();
-        let evtx_file = include_bytes!("../../samples/security.evtx");
-        let from_start_of_chunk = &evtx_file[4096..];
-
-        let mut chunk = EvtxChunkData::new(from_start_of_chunk.to_vec()).unwrap();
-        let records = chunk.parse_records().unwrap();
-        let first_record = records
-            .into_iter()
-            .next()
-            .expect("iterator to have data")
-            .expect("record to be ok");
-
-        assert_eq!(
-            first_record
-                .into_xml()
-                .unwrap()
-                .data
-                .lines()
-                .map(|l| l.trim())
-                .collect::<String>(),
-            include_str!("../../samples/security_event_1.xml")
-                .lines()
-                .map(str::trim)
-                .collect::<String>()
-        );
     }
 
     #[test]

--- a/src/evtx_parser.rs
+++ b/src/evtx_parser.rs
@@ -342,7 +342,6 @@ mod tests {
             match record {
                 Ok(r) => {
                     assert_eq!(r.event_record_id, i as u64 + 1);
-                    println!("{}", r.data);
                 }
                 Err(e) => println!("Error while reading record {}, {:?}", i, e),
             }
@@ -396,54 +395,7 @@ mod tests {
         assert!(chunk.validate_checksum());
 
         for record in chunk.parse().unwrap().into_iter() {
-            if let Err(e) = record {
-                println!("{}", e);
-                panic!();
-            }
-
-            if let Ok(r) = record {
-                println!("{}", r.into_xml().unwrap().data);
-            }
-        }
-    }
-
-    #[test]
-    // https://github.com/omerbenamram/evtx/issues/10
-    fn test_issue_10() {
-        ensure_env_logger_initialized();
-        let evtx_file = include_bytes!("../samples/2-system-Security-dirty.evtx");
-
-        let mut parser = EvtxParser::from_buffer(evtx_file.to_vec()).unwrap();
-
-        let mut count = 0;
-        for r in parser.records() {
-            r.unwrap();
-            count += 1;
-        }
-        assert_eq!(count, 14621, "Single threaded iteration failed");
-
-        let parser = EvtxParser::from_buffer(evtx_file.to_vec()).unwrap();
-        let mut parser = parser.with_configuration(ParserSettings { num_threads: 8 });
-
-        let mut count = 0;
-        for r in parser.records() {
-            r.unwrap();
-            count += 1;
-        }
-
-        assert_eq!(count, 14621, "Parallel iteration failed");
-    }
-
-    #[test]
-    fn test_parses_sample_with_irregular_boolean_values() {
-        ensure_env_logger_initialized();
-        // This sample contains boolean values which are not zero or one.
-        let evtx_file = include_bytes!("../samples/sample-with-irregular-bool-values.evtx");
-
-        let mut parser = EvtxParser::from_buffer(evtx_file.to_vec()).unwrap();
-
-        for r in parser.records() {
-            r.unwrap();
+            record.unwrap();
         }
     }
 }

--- a/src/json_output.rs
+++ b/src/json_output.rs
@@ -114,6 +114,7 @@ impl<W: Write> JsonOutput<W> {
             }
         }
 
+        // If we have attributes, create a map as usual.
         if attributes.len() > 0 {
             let value = self
                 .get_or_create_current_path()
@@ -127,7 +128,9 @@ impl<W: Write> JsonOutput<W> {
 
             value.insert("#attributes".to_owned(), Value::Object(attributes));
         } else {
-            let mut value = self.get_current_parent().as_object_mut().ok_or_else(|| {
+            // If the object does not have attributes, replace it with a null placeholder,
+            // so it will be printed as a key-value pair
+            let value = self.get_current_parent().as_object_mut().ok_or_else(|| {
                 format_err!(
                     "This is a bug - expected current value to exist, and to be an object type.\
                      Check that the value is not `Value::null`"

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,1 +1,3 @@
 mod skeptic;
+mod test_full_samples;
+mod test_record_samples;

--- a/src/tests/test_full_samples.rs
+++ b/src/tests/test_full_samples.rs
@@ -1,0 +1,49 @@
+use crate::{ensure_env_logger_initialized, EvtxParser, ParserSettings};
+
+#[test]
+// https://github.com/omerbenamram/evtx/issues/10
+fn test_dirty_sample_single_threaded() {
+    ensure_env_logger_initialized();
+    let evtx_file = include_bytes!("../../samples/2-system-Security-dirty.evtx");
+
+    let mut parser = EvtxParser::from_buffer(evtx_file.to_vec()).unwrap();
+
+    let mut count = 0;
+    for r in parser.records() {
+        r.unwrap();
+        count += 1;
+    }
+    assert_eq!(count, 14621, "Single threaded iteration failed");
+}
+
+#[test]
+fn test_dirty_sample_parallel() {
+    ensure_env_logger_initialized();
+    let evtx_file = include_bytes!("../../samples/2-system-Security-dirty.evtx");
+
+    let mut parser = EvtxParser::from_buffer(evtx_file.to_vec())
+        .unwrap()
+        .with_configuration(ParserSettings::new().num_threads(8));
+
+    let mut count = 0;
+
+    for r in parser.records() {
+        r.unwrap();
+        count += 1;
+    }
+
+    assert_eq!(count, 14621, "Parallel iteration failed");
+}
+
+#[test]
+fn test_parses_sample_with_irregular_boolean_values() {
+    ensure_env_logger_initialized();
+    // This sample contains boolean values which are not zero or one.
+    let evtx_file = include_bytes!("../../samples/sample-with-irregular-bool-values.evtx");
+
+    let mut parser = EvtxParser::from_buffer(evtx_file.to_vec()).unwrap();
+
+    for r in parser.records() {
+        r.unwrap();
+    }
+}

--- a/src/tests/test_record_samples.rs
+++ b/src/tests/test_record_samples.rs
@@ -1,11 +1,13 @@
-use crate::{ensure_env_logger_initialized, EvtxParser};
+use crate::{ensure_env_logger_initialized, EvtxParser, ParserSettings};
 use pretty_assertions::assert_eq;
 
 #[test]
 fn test_event_xml_sample() {
     ensure_env_logger_initialized();
     let evtx_file = include_bytes!("../../samples/security.evtx");
-    let mut parser = EvtxParser::from_buffer(evtx_file.to_vec()).unwrap();
+    let mut parser = EvtxParser::from_buffer(evtx_file.to_vec())
+        .unwrap()
+        .with_configuration(ParserSettings::new().num_threads(1));
 
     let first_record = parser
         .records()
@@ -30,7 +32,9 @@ fn test_event_xml_sample() {
 fn test_event_json_sample() {
     ensure_env_logger_initialized();
     let evtx_file = include_bytes!("../../samples/security.evtx");
-    let mut parser = EvtxParser::from_buffer(evtx_file.to_vec()).unwrap();
+    let mut parser = EvtxParser::from_buffer(evtx_file.to_vec())
+        .unwrap()
+        .with_configuration(ParserSettings::new().num_threads(1));
 
     let first_record = parser
         .records_json()
@@ -45,6 +49,60 @@ fn test_event_json_sample() {
             .map(|l| l.trim())
             .collect::<String>(),
         include_str!("../../samples/security_event_1.json")
+            .lines()
+            .map(str::trim)
+            .collect::<String>()
+    );
+}
+
+#[test]
+fn test_event_json_sample_with_event_data() {
+    ensure_env_logger_initialized();
+    let evtx_file = include_bytes!("../../samples/2-system-Security-dirty.evtx");
+    let mut parser = EvtxParser::from_buffer(evtx_file.to_vec())
+        .unwrap()
+        .with_configuration(ParserSettings::new().num_threads(1));
+
+    let first_record = parser
+        .records_json()
+        .next()
+        .expect("to have records")
+        .expect("record to parse correctly");
+
+    assert_eq!(
+        first_record
+            .data
+            .lines()
+            .map(|l| l.trim())
+            .collect::<String>(),
+        include_str!("../../samples/event_with_eventdata.json")
+            .lines()
+            .map(str::trim)
+            .collect::<String>()
+    );
+}
+
+#[test]
+fn test_event_xml_sample_with_event_data() {
+    ensure_env_logger_initialized();
+    let evtx_file = include_bytes!("../../samples/2-system-Security-dirty.evtx");
+    let mut parser = EvtxParser::from_buffer(evtx_file.to_vec())
+        .unwrap()
+        .with_configuration(ParserSettings::new().num_threads(1));
+
+    let first_record = parser
+        .records()
+        .next()
+        .expect("to have records")
+        .expect("record to parse correctly");
+
+    assert_eq!(
+        first_record
+            .data
+            .lines()
+            .map(|l| l.trim())
+            .collect::<String>(),
+        include_str!("../../samples/event_with_eventdata.xml")
             .lines()
             .map(str::trim)
             .collect::<String>()

--- a/src/tests/test_record_samples.rs
+++ b/src/tests/test_record_samples.rs
@@ -1,0 +1,52 @@
+use crate::{ensure_env_logger_initialized, EvtxParser};
+use pretty_assertions::assert_eq;
+
+#[test]
+fn test_event_xml_sample() {
+    ensure_env_logger_initialized();
+    let evtx_file = include_bytes!("../../samples/security.evtx");
+    let mut parser = EvtxParser::from_buffer(evtx_file.to_vec()).unwrap();
+
+    let first_record = parser
+        .records()
+        .next()
+        .expect("to have records")
+        .expect("record to parse correctly");
+
+    assert_eq!(
+        first_record
+            .data
+            .lines()
+            .map(|l| l.trim())
+            .collect::<String>(),
+        include_str!("../../samples/security_event_1.xml")
+            .lines()
+            .map(str::trim)
+            .collect::<String>()
+    );
+}
+
+#[test]
+fn test_event_json_sample() {
+    ensure_env_logger_initialized();
+    let evtx_file = include_bytes!("../../samples/security.evtx");
+    let mut parser = EvtxParser::from_buffer(evtx_file.to_vec()).unwrap();
+
+    let first_record = parser
+        .records_json()
+        .next()
+        .expect("to have records")
+        .expect("record to parse correctly");
+
+    assert_eq!(
+        first_record
+            .data
+            .lines()
+            .map(|l| l.trim())
+            .collect::<String>(),
+        include_str!("../../samples/security_event_1.json")
+            .lines()
+            .map(str::trim)
+            .collect::<String>()
+    );
+}

--- a/src/tests/test_record_samples.rs
+++ b/src/tests/test_record_samples.rs
@@ -108,3 +108,57 @@ fn test_event_xml_sample_with_event_data() {
             .collect::<String>()
     );
 }
+
+#[test]
+fn test_event_json_sample_with_event_data_with_attributes_and_text() {
+    ensure_env_logger_initialized();
+    let evtx_file = include_bytes!("../../samples/system.evtx");
+    let mut parser = EvtxParser::from_buffer(evtx_file.to_vec())
+        .unwrap()
+        .with_configuration(ParserSettings::new().num_threads(1));
+
+    let first_record = parser
+        .records_json()
+        .next()
+        .expect("to have records")
+        .expect("record to parse correctly");
+
+    assert_eq!(
+        first_record
+            .data
+            .lines()
+            .map(|l| l.trim())
+            .collect::<String>(),
+        include_str!("../../samples/event_with_text_and_attributes.json")
+            .lines()
+            .map(str::trim)
+            .collect::<String>()
+    );
+}
+
+#[test]
+fn test_event_xml_sample_with_event_data_with_attributes_and_text() {
+    ensure_env_logger_initialized();
+    let evtx_file = include_bytes!("../../samples/system.evtx");
+    let mut parser = EvtxParser::from_buffer(evtx_file.to_vec())
+        .unwrap()
+        .with_configuration(ParserSettings::new().num_threads(1));
+
+    let first_record = parser
+        .records()
+        .next()
+        .expect("to have records")
+        .expect("record to parse correctly");
+
+    assert_eq!(
+        first_record
+            .data
+            .lines()
+            .map(|l| l.trim())
+            .collect::<String>(),
+        include_str!("../../samples/event_with_text_and_attributes.xml")
+            .lines()
+            .map(str::trim)
+            .collect::<String>()
+    );
+}

--- a/src/xml_output.rs
+++ b/src/xml_output.rs
@@ -97,11 +97,13 @@ impl<W: Write> BinXmlOutput<W> for XmlOutput<W> {
         let mut event_builder = BytesStart::from(element.name.borrow().into());
 
         for attr in element.attributes.iter() {
-            let name_as_str = attr.name.as_str();
-
             let value_cow: Cow<'_, str> = attr.value.borrow().into();
-            let attr = Attribute::from((name_as_str, value_cow.as_ref()));
-            event_builder.push_attribute(attr);
+
+            if value_cow.len() > 0 {
+                let name_as_str = attr.name.as_str();
+                let attr = Attribute::from((name_as_str, value_cow.as_ref()));
+                event_builder.push_attribute(attr);
+            }
         }
 
         self.writer.write_event(Event::Start(event_builder))?;


### PR DESCRIPTION
It seems that most parsers drop empty attributes, they are noisy and IMO useless.

For JSON this means we can get nicer key-value representation, instead of the nested repr.