### PR TITLE
Added file output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0 - UNRELEASED]
+
+### Added
+- `--output` to allow writing to files, `--no-confirm-overwrite` to allow binary to overwrite existing files.
+
+
 ## [0.3.3] - 2019-05-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `--output` to allow writing to files, `--no-confirm-overwrite` to allow binary to overwrite existing files.
-
+### Changed
+- Logs are now printed to stderr instead of stdout
 
 ## [0.3.3] - 2019-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--output` to allow writing to files, `--no-confirm-overwrite` to allow binary to overwrite existing files.
 ### Changed
 - Logs are now printed to stderr instead of stdout
+- Failure exit code is now `1` instead of `-1`
 
 ## [0.3.3] - 2019-05-23
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,15 +22,15 @@ time = "0.1.42"
 encoding = "0.2.33"
 byteorder = "1.3.1"
 quick-xml = "0.14.0"
-env_logger = "0.6.1"
 snafu = { version = "0.4.1", features=["backtraces", "rust_1_30"]}
 log = { version = "^0.4", features=["release_max_level_debug"]}
 rayon = {version = "1.0.3", optional = true}
 
 # `evtx_dump` dependencies
-simple_logger = "1.0.1"
+simplelog = "0.5.3"
 clap = "2.33.0"
 dialoguer = "0.4.0"
+indoc = "0.3"
 
 serde = { version = "1.0" }
 serde_json = "1.0"
@@ -46,6 +46,7 @@ criterion = "0.2"
 skeptic = "0.13"
 assert_cmd = "0.10"
 predicates = "1"
+env_logger = "0.6.1"
 
 [build-dependencies]
 skeptic = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,12 @@ quick-xml = "0.14.0"
 env_logger = "0.6.1"
 snafu = { version = "0.4.1", features=["backtraces", "rust_1_30"]}
 log = { version = "^0.4", features=["release_max_level_debug"]}
-clap = "2.33.0"
 rayon = {version = "1.0.3", optional = true}
+
+# `evtx_dump` dependencies
 simple_logger = "1.0.1"
+clap = "2.33.0"
+dialoguer = "0.4.0"
 
 serde = { version = "1.0" }
 serde_json = "1.0"
@@ -41,6 +44,8 @@ multithreading = ["rayon"]
 pretty_assertions = "0.6.1"
 criterion = "0.2"
 skeptic = "0.13"
+assert_cmd = "0.10"
+predicates = "1"
 
 [build-dependencies]
 skeptic = "0.13"

--- a/src/bin/evtx_dump.rs
+++ b/src/bin/evtx_dump.rs
@@ -235,7 +235,7 @@ impl EvtxDump {
                         Ok(File::create(p)?)
                     }
                 }
-                None => Err("Output file cannot be root.".to_string().into()),
+                None => err!("Output file cannot be root."),
             }
         }
     }

--- a/src/bin/evtx_dump.rs
+++ b/src/bin/evtx_dump.rs
@@ -133,7 +133,7 @@ impl EvtxDump {
                 Ok(f) => Box::new(f),
                 Err(e) => {
                     eprintln!(
-                        "An error occurred while creating output `{}` - `{}`",
+                        "An error occurred while creating output file at `{}` - `{}`",
                         path, e
                     );
                     exit(1)
@@ -212,7 +212,7 @@ impl EvtxDump {
                     .default(false)
                     .interact()
                 {
-                    Ok(true) => Ok(Self::try_create_file(p)?),
+                    Ok(true) => Ok(File::create(p)?),
                     Ok(false) => err!("Cancelled"),
                     Err(e) => err!(
                         "Failed to write confirmation prompt to term caused by\n{}",
@@ -220,7 +220,7 @@ impl EvtxDump {
                     ),
                 }
             } else {
-                Ok(Self::try_create_file(p)?)
+                Ok(File::create(p)?)
             }
         } else {
             // Ok to assume p is not an existing directory
@@ -229,28 +229,14 @@ impl EvtxDump {
                 // Parent exist
                 {
                     if parent.exists() {
-                        Ok(Self::try_create_file(p)?)
+                        Ok(File::create(p)?)
                     } else {
                         fs::create_dir_all(parent)?;
-                        Ok(Self::try_create_file(p)?)
+                        Ok(File::create(p)?)
                     }
                 }
                 None => Err("Output file cannot be root.".to_string().into()),
             }
-        }
-    }
-
-    /// Tries to create a file, will abort program on failure
-    fn try_create_file(p: impl AsRef<Path>) -> Result<File, Box<std::error::Error>> {
-        let p = p.as_ref();
-
-        match File::create(p) {
-            Ok(f) => Ok(f),
-            Err(e) => err!(
-                "Failed to write to output target `{}`, caused by\n{}",
-                p.display(),
-                e
-            ),
         }
     }
 


### PR DESCRIPTION
This is useful when using `EvtxDump` for scipts, it will allow for stuff like

// Convert all evtx files to xml

in fish: `fd -e evtx -x evtx_dump {} -f \{.\}.xml`
in bash: `fd -e evtx -x evtx_dump {} -f {.}.xml`