### PR TITLE
Feature/records serde json value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.3 - 2019-10-07]
 
 ### Added
-- `EvtxRecord::into_json_value()` to allow working with records with a `serde_json::Value`. See `test_into_json_value_records` for an example.
+- `EvtxParser::records_json_value()` to allow working with records with a `serde_json::Value`. See `test_into_json_value_records` for an example.
 
 ## [0.4.2 - 2019-09-05]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.3 - 2019-10-07]
+## [0.5.0 - 2019-10-07]
 
 ### Added
 - `EvtxParser::records_json_value()` to allow working with records with a `serde_json::Value`. See `test_into_json_value_records` for an example.
+
+### Changed
+
+- `SerializedEvtxRecord` is now generic over it's `data`, allowing a simplified `BinXmlOutput` trait.
 
 ## [0.4.2 - 2019-09-05]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3 - 2019-10-07]
+
+### Added
+- `EvtxRecord::into_json_value()` to allow working with records with a `serde_json::Value`. See `test_into_json_value_records` for an example.
+
 ## [0.4.2 - 2019-09-05]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `EvtxParser::records_json_value()` to allow working with records with a `serde_json::Value`. See `test_into_json_value_records` for an example.
+- `EvtxRecord::into_output`, allowing serializing a record using a user-defined `BinXmlOutput` type.
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/omerbenamram/EVTX"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 
-version = "0.4.3-alpha.0"
+version = "0.5.0-alpha.0"
 authors = ["Omer Ben-Amram <omerbenamram@gmail.com>"]
 edition = "2018"
 

--- a/src/bin/evtx_dump.rs
+++ b/src/bin/evtx_dump.rs
@@ -230,7 +230,10 @@ impl EvtxDump {
         }
     }
 
-    fn dump_record(&mut self, record: Result<SerializedEvtxRecord, Error>) -> Result<(), Error> {
+    fn dump_record(
+        &mut self,
+        record: Result<SerializedEvtxRecord<String>, Error>,
+    ) -> Result<(), Error> {
         match record {
             Ok(r) => {
                 if self.show_record_number {

--- a/src/binxml/assemble.rs
+++ b/src/binxml/assemble.rs
@@ -11,7 +11,7 @@ use std::borrow::Cow;
 use std::io::Write;
 use std::mem;
 
-pub fn parse_tokens<W: Write, T: BinXmlOutput<W>>(
+pub fn parse_tokens<T: BinXmlOutput>(
     tokens: Vec<BinXMLDeserializedTokens>,
     visitor: &mut T,
 ) -> Result<()> {

--- a/src/evtx_chunk.rs
+++ b/src/evtx_chunk.rs
@@ -156,6 +156,10 @@ impl<'chunk> EvtxChunk<'chunk> {
 
     /// Return an iterator of records from the chunk.
     /// See `IterChunkRecords` for more lifetime info.
+    ///
+    /// NOTE: The lifetime bound should be the reverse,
+    /// but because `Cow` is invariant w.r.t. it's lifetime we have to 'force' the ref to self
+    /// to be bigger than the 'chunk life time.
     pub fn iter<'a: 'chunk>(&'a mut self) -> IterChunkRecords {
         IterChunkRecords {
             settings: self.settings,
@@ -163,14 +167,6 @@ impl<'chunk> EvtxChunk<'chunk> {
             offset_from_chunk_start: EVTX_CHUNK_HEADER_SIZE as u64,
             exhausted: false,
         }
-    }
-
-    /// Return an iterator of serialized records (containing textual data, not tokens) from the chunk.
-    pub fn iter_serialized_records<'a: 'chunk, O: BinXmlOutput<Vec<u8>>>(
-        &'a mut self,
-    ) -> impl Iterator<Item = Result<SerializedEvtxRecord>> + 'a {
-        self.iter()
-            .map(|record_res| record_res.and_then(evtx_record::EvtxRecord::into_serialized::<O>))
     }
 }
 

--- a/src/evtx_chunk.rs
+++ b/src/evtx_chunk.rs
@@ -159,7 +159,7 @@ impl<'chunk> EvtxChunk<'chunk> {
     ///
     /// NOTE: The lifetime bound should be the reverse,
     /// but because `Cow` is invariant w.r.t. it's lifetime we have to 'force' the ref to self
-    /// to be bigger than the 'chunk life time.
+    /// to be bigger than the 'chunk lifetime.
     pub fn iter<'a: 'chunk>(&'a mut self) -> IterChunkRecords {
         IterChunkRecords {
             settings: self.settings,

--- a/src/evtx_parser.rs
+++ b/src/evtx_parser.rs
@@ -354,7 +354,7 @@ impl<T: ReadSeek> EvtxParser<T> {
     /// Records will be mapped `f`, which must produce owned data from the records.
     pub fn serialized_records<'a, U: Send>(
         &'a mut self,
-        f: impl FnMut(Result<EvtxRecord<'_>>) -> Result<U> + Send + Sync + Copy + 'a,
+        f: impl FnMut(Result<EvtxRecord<'_>>) -> Result<U> + Send + Sync + Clone + 'a,
     ) -> impl Iterator<Item = Result<U>> + '_ {
         let num_threads = max(self.config.num_threads, 1);
         let chunk_settings = self.config.clone();
@@ -390,7 +390,7 @@ impl<T: ReadSeek> EvtxParser<T> {
 
                             match chunk_records_res {
                                 Err(err) => vec![Err(err)],
-                                Ok(mut chunk_records) => chunk_records.iter().map(f).collect(),
+                                Ok(mut chunk_records) => chunk_records.iter().map(f.clone()).collect(),
                             }
                         }
                     })

--- a/src/evtx_parser.rs
+++ b/src/evtx_parser.rs
@@ -615,4 +615,25 @@ mod tests {
         assert_eq!(records.len(), 1);
     }
 
+    #[test]
+    fn test_into_json_value_records() {
+        ensure_env_logger_initialized();
+        let evtx_file = include_bytes!("../samples/new-user-security.evtx");
+        let parser = EvtxParser::from_buffer(evtx_file.to_vec()).unwrap();
+
+        let chunks: Vec<_> = parser.into_chunks().collect();
+
+        for chunk in chunks {
+            let mut chunk = chunk.unwrap();
+
+            for record in chunk.parse(&ParserSettings::default()).unwrap().iter() {
+                let record = record.unwrap();
+
+                let record_with_json_value = record.into_json_value().unwrap();
+
+                assert!(record_with_json_value.data.is_object());
+                assert!(record_with_json_value.data.as_object().unwrap().contains_key("Event"));
+            }
+        }
+    }
 }

--- a/src/evtx_parser.rs
+++ b/src/evtx_parser.rs
@@ -3,7 +3,7 @@ use snafu::{ensure, ResultExt};
 
 use crate::evtx_chunk::EvtxChunkData;
 use crate::evtx_file_header::EvtxFileHeader;
-use crate::evtx_record::SerializedEvtxRecord;
+use crate::evtx_record::{EvtxRecordWithJsonValue, SerializedEvtxRecord};
 #[cfg(feature = "multithreading")]
 use rayon;
 #[cfg(feature = "multithreading")]
@@ -17,6 +17,7 @@ use std::iter::{IntoIterator, Iterator};
 
 use crate::json_output::JsonOutput;
 use crate::xml_output::{BinXmlOutput, XmlOutput};
+use crate::EvtxRecord;
 use encoding::all::WINDOWS_1252;
 use encoding::EncodingRef;
 use std::cmp::max;
@@ -97,8 +98,8 @@ pub struct ParserSettings {
     ///     "#text": 4111
     ///   }
     /// }
-    /// 
-    /// Becomes: 
+    ///
+    /// Becomes:
     /// {
     ///   "EventID": 4111,
     ///   "EventID_attributes": {
@@ -349,12 +350,12 @@ impl<T: ReadSeek> EvtxParser<T> {
             current_chunk_number: 0,
         }
     }
-
     /// Return an iterator over all the records.
-    /// Records will be serialized using the given `BinXmlOutput`.
-    pub fn serialized_records<O: BinXmlOutput<Vec<u8>>>(
-        &mut self,
-    ) -> impl Iterator<Item = Result<SerializedEvtxRecord>> + '_ {
+    /// Records will be mapped `f`, which must produce owned data from the records.
+    pub fn owned_records<'a, U: Send>(
+        &'a mut self,
+        f: impl FnMut(Result<EvtxRecord<'_>>) -> Result<U> + Send + Sync + Copy + 'a,
+    ) -> impl Iterator<Item = Result<U>> + '_ {
         let num_threads = max(self.config.num_threads, 1);
         let chunk_settings = self.config.clone();
 
@@ -381,7 +382,7 @@ impl<T: ReadSeek> EvtxParser<T> {
                 let chunk_iter = chunk_of_chunks.into_iter();
 
                 // Serialize the records in each chunk.
-                let iterators: Vec<Vec<Result<SerializedEvtxRecord>>> = chunk_iter
+                let iterators: Vec<Vec<Result<U>>> = chunk_iter
                     .map(|chunk_res| match chunk_res {
                         Err(err) => vec![Err(err)],
                         Ok(mut chunk) => {
@@ -389,9 +390,7 @@ impl<T: ReadSeek> EvtxParser<T> {
 
                             match chunk_records_res {
                                 Err(err) => vec![Err(err)],
-                                Ok(mut chunk_records) => {
-                                    chunk_records.iter_serialized_records::<O>().collect()
-                                }
+                                Ok(mut chunk_records) => chunk_records.iter().map(f).collect(),
                             }
                         }
                     })
@@ -405,6 +404,14 @@ impl<T: ReadSeek> EvtxParser<T> {
     }
 
     /// Return an iterator over all the records.
+    /// Records will be serialized using the given `BinXmlOutput`.
+    pub fn serialized_records<O: BinXmlOutput<Vec<u8>>>(
+        &mut self,
+    ) -> impl Iterator<Item = Result<SerializedEvtxRecord>> + '_ {
+        self.owned_records(|record| record.and_then(|record| record.into_serialized::<O>()))
+    }
+
+    /// Return an iterator over all the records.
     /// Records will be XML-formatted.
     pub fn records(&mut self) -> impl Iterator<Item = Result<SerializedEvtxRecord>> + '_ {
         // '_ is required in the signature because the iterator is bound to &self.
@@ -415,6 +422,14 @@ impl<T: ReadSeek> EvtxParser<T> {
     /// Records will be JSON-formatted.
     pub fn records_json(&mut self) -> impl Iterator<Item = Result<SerializedEvtxRecord>> + '_ {
         self.serialized_records::<JsonOutput<Vec<u8>>>()
+    }
+
+    /// Return an iterator over all the records.
+    /// Records will have a `serde_json::Value` data attribute.
+    pub fn records_json_value(
+        &mut self,
+    ) -> impl Iterator<Item = Result<EvtxRecordWithJsonValue>> + '_ {
+        self.owned_records(|record| record.and_then(|record| record.into_json_value()))
     }
 }
 
@@ -619,21 +634,15 @@ mod tests {
     fn test_into_json_value_records() {
         ensure_env_logger_initialized();
         let evtx_file = include_bytes!("../samples/new-user-security.evtx");
-        let parser = EvtxParser::from_buffer(evtx_file.to_vec()).unwrap();
+        let mut parser = EvtxParser::from_buffer(evtx_file.to_vec()).unwrap();
 
-        let chunks: Vec<_> = parser.into_chunks().collect();
+        let records: Vec<_> = parser.records_json_value().collect();
 
-        for chunk in chunks {
-            let mut chunk = chunk.unwrap();
+        for record in records {
+            let record = record.unwrap();
 
-            for record in chunk.parse(&ParserSettings::default()).unwrap().iter() {
-                let record = record.unwrap();
-
-                let record_with_json_value = record.into_json_value().unwrap();
-
-                assert!(record_with_json_value.data.is_object());
-                assert!(record_with_json_value.data.as_object().unwrap().contains_key("Event"));
-            }
+            assert!(record.data.is_object());
+            assert!(record.data.as_object().unwrap().contains_key("Event"));
         }
     }
 }

--- a/src/evtx_record.rs
+++ b/src/evtx_record.rs
@@ -10,8 +10,8 @@ use std::io::{Cursor, Read};
 
 use byteorder::ReadBytesExt;
 use chrono::prelude::*;
-use snafu::{ensure, ResultExt};
 use serde_json::Value;
+use snafu::{ensure, ResultExt};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct EvtxRecord<'a> {

--- a/src/json_output.rs
+++ b/src/json_output.rs
@@ -18,7 +18,6 @@ pub struct JsonOutput {
     map: Value,
     stack: Vec<String>,
     separate_json_attributes: bool,
-    indent: bool,
 }
 
 impl JsonOutput {
@@ -27,25 +26,7 @@ impl JsonOutput {
             map: Value::Object(Map::new()),
             stack: vec![],
             separate_json_attributes: settings.should_separate_json_attributes(),
-            indent: settings.should_indent(),
         }
-    }
-
-    pub fn to_writer<W: Write>(&self, writer: &mut W) -> Result<()> {
-        ensure!(
-            self.stack.is_empty(),
-            err::JsonStructureError {
-                message: "Invalid stream, EOF reached before closing all attributes"
-            }
-        );
-
-        if self.indent {
-            serde_json::to_writer_pretty(writer, &self.map).context(err::JsonError)?;
-        } else {
-            serde_json::to_writer(writer, &self.map).context(err::JsonError)?;
-        }
-
-        Ok(())
     }
 
     /// Looks up the current path, will fill with empty objects if needed.

--- a/src/json_output.rs
+++ b/src/json_output.rs
@@ -3,9 +3,9 @@ use snafu::{ensure, OptionExt, ResultExt};
 
 use crate::binxml::value_variant::BinXmlValue;
 use crate::model::xml::XmlElement;
+use crate::unimplemented_fn;
 use crate::xml_output::BinXmlOutput;
 use crate::ParserSettings;
-use crate::{unimplemented_fn};
 
 use core::borrow::BorrowMut;
 use log::trace;
@@ -14,15 +14,40 @@ use std::borrow::Cow;
 use std::io::Write;
 use std::mem;
 
-pub struct JsonOutput<W: Write> {
-    writer: W,
+pub struct JsonOutput {
     map: Value,
     stack: Vec<String>,
     separate_json_attributes: bool,
     indent: bool,
 }
 
-impl<W: Write> JsonOutput<W> {
+impl JsonOutput {
+    pub fn new(settings: &ParserSettings) -> Self {
+        JsonOutput {
+            map: Value::Object(Map::new()),
+            stack: vec![],
+            separate_json_attributes: settings.should_separate_json_attributes(),
+            indent: settings.should_indent(),
+        }
+    }
+
+    pub fn to_writer<W: Write>(&self, writer: &mut W) -> Result<()> {
+        ensure!(
+            self.stack.is_empty(),
+            err::JsonStructureError {
+                message: "Invalid stream, EOF reached before closing all attributes"
+            }
+        );
+
+        if self.indent {
+            serde_json::to_writer_pretty(writer, &self.map).context(err::JsonError)?;
+        } else {
+            serde_json::to_writer(writer, &self.map).context(err::JsonError)?;
+        }
+
+        Ok(())
+    }
+
     /// Looks up the current path, will fill with empty objects if needed.
     fn get_or_create_current_path(&mut self) -> &mut Value {
         let mut v_temp = self.map.borrow_mut();
@@ -128,9 +153,10 @@ impl<W: Write> JsonOutput<W> {
         if !attributes.is_empty() {
             if self.separate_json_attributes {
                 // If we are separating the attributes we want
-                // to insert the object for the attributes 
-                // into the parent. 
-                let value = self.get_current_parent()
+                // to insert the object for the attributes
+                // into the parent.
+                let value = self
+                    .get_current_parent()
                     .as_object_mut()
                     .context(err::JsonStructureError {
                     message:
@@ -139,16 +165,15 @@ impl<W: Write> JsonOutput<W> {
                 })?;
 
                 value.insert(format!("{}_attributes", name), Value::Object(attributes));
-            }
-            else {
-                let value =
-                    self.get_or_create_current_path()
-                        .as_object_mut()
-                        .context(err::JsonStructureError {
-                        message:
-                            "This is a bug - expected current value to exist, and to be an object type.
+            } else {
+                let value = self
+                    .get_or_create_current_path()
+                    .as_object_mut()
+                    .context(err::JsonStructureError {
+                    message:
+                        "This is a bug - expected current value to exist, and to be an object type.
                             Check that the value is not `Value::null`",
-                    })?;
+                })?;
 
                 value.insert("#attributes".to_owned(), Value::Object(attributes));
             }
@@ -182,33 +207,7 @@ impl<W: Write> JsonOutput<W> {
     }
 }
 
-impl<W: Write> BinXmlOutput<W> for JsonOutput<W> {
-    fn with_writer(target: W, settings: &ParserSettings) -> Self {
-        JsonOutput {
-            writer: target,
-            map: Value::Object(Map::new()),
-            stack: vec![],
-            separate_json_attributes: settings.should_separate_json_attributes(),
-            indent: settings.should_indent(),
-        }
-    }
-
-    fn into_writer(mut self) -> Result<W> {
-        ensure!(
-            self.stack.is_empty(),
-            err::JsonStructureError {
-                message: "Invalid stream, EOF reached before closing all attributes"
-            }
-        );
-
-        if self.indent {
-            serde_json::to_writer_pretty(&mut self.writer, &self.map).context(err::JsonError)?;
-        } else {
-            serde_json::to_writer(&mut self.writer, &self.map).context(err::JsonError)?;
-        }
-        Ok(self.writer)
-    }
-
+impl BinXmlOutput for JsonOutput {
     fn visit_end_of_stream(&mut self) -> Result<()> {
         trace!("visit_end_of_stream");
         Ok(())

--- a/src/json_output.rs
+++ b/src/json_output.rs
@@ -169,6 +169,17 @@ impl<W: Write> JsonOutput<W> {
 
         Ok(())
     }
+
+    pub fn into_value(self) -> Result<Value> {
+        ensure!(
+            self.stack.is_empty(),
+            err::JsonStructureError {
+                message: "Invalid stream, EOF reached before closing all attributes"
+            }
+        );
+
+        Ok(self.map)
+    }
 }
 
 impl<W: Write> BinXmlOutput<W> for JsonOutput<W> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,10 +31,10 @@ pub type Offset = u32;
 
 // For tests, we only initialize logging once.
 #[cfg(test)]
-use std::sync::{Once, ONCE_INIT};
+use std::sync::Once;
 
 #[cfg(test)]
-static LOGGER_INIT: Once = ONCE_INIT;
+static LOGGER_INIT: Once = Once::new();
 
 // Rust runs the tests concurrently, so unless we synchronize logging access
 // it will crash when attempting to run `cargo test` with some logging facilities.

--- a/tests/fixtures.rs
+++ b/tests/fixtures.rs
@@ -1,9 +1,9 @@
 #![allow(dead_code)]
 use std::path::PathBuf;
 
-use std::sync::{Once, ONCE_INIT};
+use std::sync::Once;
 
-static LOGGER_INIT: Once = ONCE_INIT;
+static LOGGER_INIT: Once = Once::new();
 
 // Rust runs the tests concurrently, so unless we synchronize logging access
 // it will crash when attempting to run `cargo test` with some logging facilities.

--- a/tests/test_record_samples.rs
+++ b/tests/test_record_samples.rs
@@ -178,7 +178,7 @@ fn test_event_json_sample_with_separate_json_attributes() {
         .with_configuration(
             ParserSettings::new()
                 .num_threads(1)
-                .separate_json_attributes(true)
+                .separate_json_attributes(true),
         );
 
     let first_record = parser


### PR DESCRIPTION
Allow the user to iterate over records with `serde_json::Value` data.


Closes #55

-----

```
read 90 records         time:   [5.9722 ms 6.0193 ms 6.0684 ms]
                        change: [-0.1850% +1.1088% +2.3223%] (p = 0.09 > 0.05)
                        No change in performance detected.

Benchmarking read 90 records json: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 41.1s or reduce sample count to 20
read 90 records json    time:   [8.0400 ms 8.0824 ms 8.1262 ms]
                        change: [-0.8118% +0.2050% +1.2236%] (p = 0.69 > 0.05)
                        No change in performance detected.
```