### PR TITLE
Read the entire template cache upfront

### DIFF
--- a/src/bin/evtx_dump.rs
+++ b/src/bin/evtx_dump.rs
@@ -79,7 +79,8 @@ impl EvtxDump {
         };
 
         let num_threads = matches
-            .value_of("num-threads").map(|value| value.parse::<usize>().expect("used validator"));
+            .value_of("num-threads")
+            .map(|value| value.parse::<usize>().expect("used validator"));
 
         let num_threads = match (cfg!(feature = "multithreading"), num_threads) {
             (true, Some(number)) => number,

--- a/src/bin/evtx_dump.rs
+++ b/src/bin/evtx_dump.rs
@@ -79,8 +79,7 @@ impl EvtxDump {
         };
 
         let num_threads = matches
-            .value_of("num-threads")
-            .and_then(|value| Some(value.parse::<usize>().expect("used validator")));
+            .value_of("num-threads").map(|value| value.parse::<usize>().expect("used validator"));
 
         let num_threads = match (cfg!(feature = "multithreading"), num_threads) {
             (true, Some(number)) => number,

--- a/src/binxml/assemble.rs
+++ b/src/binxml/assemble.rs
@@ -334,8 +334,6 @@ fn expand_template<'a>(
                 _expand_templates(Cow::Owned(token), chunk, stack)?;
             }
         }
-
-        return Ok(());
     };
 
     Ok(())

--- a/src/binxml/assemble.rs
+++ b/src/binxml/assemble.rs
@@ -1,19 +1,24 @@
 use crate::err::{EvtxError, Result};
 
 use crate::binxml::value_variant::BinXmlValue;
-use crate::model::deserialized::{BinXMLDeserializedTokens, BinXmlTemplate, BinXMLTemplateDefinitionCow};
+use crate::model::deserialized::{BinXMLDeserializedTokens, BinXmlTemplate};
 use crate::model::xml::{XmlElementBuilder, XmlModel, XmlPIBuilder};
 use crate::xml_output::BinXmlOutput;
 use log::{trace, warn};
 use std::borrow::{Borrow, BorrowMut, Cow};
 
 use std::mem;
+use crate::EvtxChunk;
+use crate::template_cache::TemplateCache;
+use std::cell::Ref;
+use std::ops::Deref;
 
-pub fn parse_tokens<T: BinXmlOutput>(
-    tokens: Vec<BinXMLDeserializedTokens>,
+pub fn parse_tokens<'a, T: BinXmlOutput>(
+    tokens: Vec<BinXMLDeserializedTokens<'a>>,
+    template_cache: &'a TemplateCache<'a>,
     visitor: &mut T,
 ) -> Result<()> {
-    let expanded_tokens = expand_templates(tokens);
+    let expanded_tokens = expand_templates(tokens, template_cache);
     let record_model = create_record_model(expanded_tokens)?;
 
     visitor.visit_start_of_stream()?;
@@ -82,7 +87,7 @@ pub fn create_record_model<'a>(
                     None => {
                         return Err(EvtxError::FailedToCreateRecordModel(
                             "close start - Bad parser state",
-                        ))
+                        ));
                     }
                     Some(builder) => model.push(XmlModel::OpenElement(builder.finish()?)),
                 };
@@ -91,13 +96,13 @@ pub fn create_record_model<'a>(
             | Cow::Borrowed(BinXMLDeserializedTokens::CDATASection) => {
                 return Err(EvtxError::FailedToCreateRecordModel(
                     "Unimplemented - CDATA",
-                ))
+                ));
             }
             Cow::Owned(BinXMLDeserializedTokens::CharRef)
             | Cow::Borrowed(BinXMLDeserializedTokens::CharRef) => {
                 return Err(EvtxError::FailedToCreateRecordModel(
                     "Unimplemented - CharacterReference",
-                ))
+                ));
             }
             Cow::Owned(BinXMLDeserializedTokens::EntityRef(entity)) => {
                 model.push(XmlModel::EntityRef(Cow::Owned(entity.name)))
@@ -120,7 +125,7 @@ pub fn create_record_model<'a>(
                 None => {
                     return Err(EvtxError::FailedToCreateRecordModel(
                         "PI Data without PI target - Bad parser state",
-                    ))
+                    ));
                 }
                 Some(builder) => {
                     model.push(builder.data(data).finish());
@@ -130,7 +135,7 @@ pub fn create_record_model<'a>(
                 None => {
                     return Err(EvtxError::FailedToCreateRecordModel(
                         "PI Data without PI target - Bad parser state",
-                    ))
+                    ));
                 }
                 Some(builder) => {
                     model.push(builder.data(Cow::Borrowed(data)).finish());
@@ -140,7 +145,7 @@ pub fn create_record_model<'a>(
             | Cow::Borrowed(BinXMLDeserializedTokens::Substitution(_)) => {
                 return Err(EvtxError::FailedToCreateRecordModel(
                     "Call `expand_templates` before calling this function",
-                ))
+                ));
             }
             Cow::Owned(BinXMLDeserializedTokens::EndOfStream)
             | Cow::Borrowed(BinXMLDeserializedTokens::EndOfStream) => {
@@ -158,7 +163,7 @@ pub fn create_record_model<'a>(
                     None => {
                         return Err(EvtxError::FailedToCreateRecordModel(
                             "close empty - Bad parser state",
-                        ))
+                        ));
                     }
                     Some(builder) => {
                         model.push(XmlModel::OpenElement(builder.finish()?));
@@ -173,7 +178,7 @@ pub fn create_record_model<'a>(
                     None => {
                         return Err(EvtxError::FailedToCreateRecordModel(
                             "attribute - Bad parser state",
-                        ))
+                        ));
                     }
                     Some(builder) => {
                         current_element = Some(builder.attribute_name(Cow::Owned(attr.name)));
@@ -187,7 +192,7 @@ pub fn create_record_model<'a>(
                     None => {
                         return Err(EvtxError::FailedToCreateRecordModel(
                             "attribute - Bad parser state",
-                        ))
+                        ));
                     }
                     Some(builder) => {
                         current_element = Some(builder.attribute_name(Cow::Borrowed(&attr.name)));
@@ -258,63 +263,15 @@ pub fn create_record_model<'a>(
     Ok(model)
 }
 
-fn expand_owned_template<'a>(
-    mut template: BinXmlTemplate<'a>,
-    stack: &mut Vec<Cow<'a, BinXMLDeserializedTokens<'a>>>,
-) {
-    // If the template owns the definition, we can consume the tokens.
-    let tokens: Vec<Cow<'a, BinXMLDeserializedTokens<'a>>> = match template.definition {
-        BinXMLTemplateDefinitionCow::Owned(owned_def) => owned_def.tokens.into_iter().map(Cow::Owned).collect(),
-        BinXMLTemplateDefinitionCow::Borrowed(ref_def) => ref_def.tokens.iter().map(Cow::Borrowed).collect(),
-    };
-
-    for token in tokens {
-        if let BinXMLDeserializedTokens::Substitution(ref substitution_descriptor) = token.as_ref()
-        {
-            if substitution_descriptor.ignore {
-                continue;
-            } else {
-                // We swap out the node in the substitution array with a dummy value (to avoid copying it),
-                // moving control of the original node to the new token tree.
-                let value = template
-                    .substitution_array
-                    .get_mut(substitution_descriptor.substitution_index as usize);
-
-                if let Some(value) = value {
-                    let value = mem::replace(
-                        value,
-                        BinXMLDeserializedTokens::Value(BinXmlValue::NullType),
-                    );
-
-                    _expand_templates(
-                        Cow::Owned(value),
-                        stack,
-                    );
-                } else {
-                    _expand_templates(
-                        Cow::Owned(BinXMLDeserializedTokens::Value(BinXmlValue::NullType)),
-                        stack,
-                    );
-                }
-            }
-        } else {
-            _expand_templates(token, stack);
-        }
-    }
-}
 
 fn expand_borrowed_template<'a>(
     template: &'a BinXmlTemplate<'a>,
+    template_cache: &'a TemplateCache<'a>,
     stack: &mut Vec<Cow<'a, BinXMLDeserializedTokens<'a>>>,
 ) {
-    // Here we can always use refs, since even if the definition is owned by the template,
-    // we do not own it.
-    let tokens = match template.definition {
-        BinXMLTemplateDefinitionCow::Owned(ref def) => &def.tokens,
-        BinXMLTemplateDefinitionCow::Borrowed(def) => &def.tokens,
-    };
+    let template_def = template_cache.get_template(template.template_def_offset).unwrap();
 
-    for token in tokens.iter() {
+    for token in template_def.tokens.iter() {
         if let BinXMLDeserializedTokens::Substitution(ref substitution_descriptor) = token {
             if substitution_descriptor.ignore {
                 continue;
@@ -326,23 +283,66 @@ fn expand_borrowed_template<'a>(
                 if let Some(value) = value {
                     _expand_templates(
                         Cow::Borrowed(value),
+                        template_cache,
                         stack,
                     );
                 } else {
                     _expand_templates(
                         Cow::Owned(BinXMLDeserializedTokens::Value(BinXmlValue::NullType)),
+                        template_cache,
                         stack,
                     );
                 }
             }
         } else {
-            _expand_templates(Cow::Borrowed(token), stack);
+            _expand_templates(Cow::Borrowed(token), template_cache, stack);
+        }
+    }
+}
+
+
+fn expand_owned_template<'a, 'b>(
+    mut template: BinXmlTemplate<'a>,
+    template_cache: &'a TemplateCache<'a>,
+    stack: &mut Vec<Cow<'a, BinXMLDeserializedTokens<'a>>>,
+) {
+    let template_def = template_cache.get_template(template.template_def_offset).unwrap();
+
+    for token in template_def.tokens.iter() {
+        if let BinXMLDeserializedTokens::Substitution(ref substitution_descriptor) = token {
+            if substitution_descriptor.ignore {
+                continue;
+            } else {
+                let value = template
+                    .substitution_array
+                    .get_mut(substitution_descriptor.substitution_index as usize);
+
+
+                if let Some(value) = value {
+                    let value = mem::replace(value,
+                                             BinXMLDeserializedTokens::Value(BinXmlValue::NullType));
+                    _expand_templates(
+                        Cow::Owned(value),
+                        template_cache,
+                        stack,
+                    );
+                } else {
+                    _expand_templates(
+                        Cow::Owned(BinXMLDeserializedTokens::Value(BinXmlValue::NullType)),
+                        template_cache,
+                        stack,
+                    );
+                }
+            }
+        } else {
+            _expand_templates(Cow::Borrowed(token), template_cache, stack);
         }
     }
 }
 
 fn _expand_templates<'a>(
     token: Cow<'a, BinXMLDeserializedTokens<'a>>,
+    template_cache: &'a TemplateCache<'a>,
     stack: &mut Vec<Cow<'a, BinXMLDeserializedTokens<'a>>>,
 ) {
     match token {
@@ -351,7 +351,7 @@ fn _expand_templates<'a>(
                                                        tokens,
                                                    ))) => {
             for token in tokens.into_iter() {
-                _expand_templates(Cow::Owned(token), stack);
+                _expand_templates(Cow::Owned(token), template_cache, stack);
             }
         }
 
@@ -359,30 +359,31 @@ fn _expand_templates<'a>(
                                                           tokens,
                                                       ))) => {
             for token in tokens.iter() {
-                _expand_templates(Cow::Borrowed(token), stack);
+                _expand_templates(Cow::Borrowed(token), template_cache, stack);
             }
         }
 
         // Actual template handling.
         Cow::Owned(BinXMLDeserializedTokens::TemplateInstance(template)) => {
-            expand_owned_template(template, stack);
+            expand_owned_template(template, template_cache, stack);
         }
         Cow::Borrowed(BinXMLDeserializedTokens::TemplateInstance(template)) => {
-            expand_borrowed_template(template, stack);
+            expand_borrowed_template(template, template_cache, stack);
         }
 
         _ => stack.push(token),
     }
 }
 
-pub fn expand_templates(
-    token_tree: Vec<BinXMLDeserializedTokens>,
-) -> Vec<Cow<BinXMLDeserializedTokens>> {
+pub fn expand_templates<'a>(
+    token_tree: Vec<BinXMLDeserializedTokens<'a>>,
+    template_cache: &'a TemplateCache<'a>,
+) -> Vec<Cow<'a, BinXMLDeserializedTokens<'a>>> {
     // We can assume the new tree will be at least as big as the old one.
     let mut stack = Vec::with_capacity(token_tree.len());
 
     for token in token_tree {
-        _expand_templates(Cow::Owned(token), &mut stack)
+        _expand_templates(Cow::Owned(token), template_cache, &mut stack)
     }
 
     stack

--- a/src/binxml/assemble.rs
+++ b/src/binxml/assemble.rs
@@ -307,7 +307,6 @@ fn expand_template<'a>(
     } else {
         // There can be a template which was not found in the header, if the file was not closed correctly.
         // In that case, we will try to read it directly from the chunk.
-
         debug!("Template in offset {} was not found in cache", template.template_def_offset);
         let mut cursor = Cursor::new(chunk.data);
         let _ = cursor.seek(SeekFrom::Start(u64::from(template.template_def_offset)));
@@ -362,6 +361,9 @@ fn _expand_templates<'a>(
             expand_template(template, chunk, stack);
         }
         Cow::Borrowed(BinXMLDeserializedTokens::TemplateInstance(template)) => {
+            // This can happen if a template has a token which is:
+            // 1. Another template.
+            // 2. Is not a substitution (because they are `Owned` values).
             // We never actually see this in practice, so we don't mind paying for `clone` here.
             expand_template(template.clone(), chunk, stack);
         }

--- a/src/binxml/assemble.rs
+++ b/src/binxml/assemble.rs
@@ -5,13 +5,13 @@ use crate::model::deserialized::{BinXMLDeserializedTokens, BinXmlTemplate};
 use crate::model::xml::{XmlElementBuilder, XmlModel, XmlPIBuilder};
 use crate::xml_output::BinXmlOutput;
 use log::{trace, warn};
-use std::borrow::{Borrow, BorrowMut, Cow};
+use std::borrow::{Cow};
 
 use std::mem;
-use crate::EvtxChunk;
+
 use crate::template_cache::TemplateCache;
-use std::cell::Ref;
-use std::ops::Deref;
+
+
 
 pub fn parse_tokens<'a, T: BinXmlOutput>(
     tokens: Vec<BinXMLDeserializedTokens<'a>>,

--- a/src/binxml/assemble.rs
+++ b/src/binxml/assemble.rs
@@ -1,7 +1,7 @@
 use crate::err::{EvtxError, Result};
 
 use crate::binxml::value_variant::BinXmlValue;
-use crate::model::deserialized::{BinXMLDeserializedTokens, BinXmlTemplate, TemplateSubstitutionDescriptor};
+use crate::model::deserialized::{BinXMLDeserializedTokens, BinXmlTemplateRef, TemplateSubstitutionDescriptor};
 use crate::model::xml::{XmlElementBuilder, XmlModel, XmlPIBuilder};
 use crate::xml_output::BinXmlOutput;
 use log::{trace, warn, debug};
@@ -266,7 +266,7 @@ pub fn create_record_model<'a>(
 }
 
 fn expand_token_substitution<'a>(
-    template: &mut BinXmlTemplate<'a>,
+    template: &mut BinXmlTemplateRef<'a>,
     substitution_descriptor: &TemplateSubstitutionDescriptor,
     chunk: &'a EvtxChunk<'a>,
     stack: &mut Vec<Cow<'a, BinXMLDeserializedTokens<'a>>>,
@@ -298,7 +298,7 @@ fn expand_token_substitution<'a>(
 }
 
 fn expand_template<'a>(
-    mut template: BinXmlTemplate<'a>,
+    mut template: BinXmlTemplateRef<'a>,
     chunk: &'a EvtxChunk<'a>,
     stack: &mut Vec<Cow<'a, BinXMLDeserializedTokens<'a>>>,
 ) {

--- a/src/binxml/assemble.rs
+++ b/src/binxml/assemble.rs
@@ -9,7 +9,7 @@ use std::borrow::Cow;
 
 use std::mem;
 
-use crate::template_cache::CachedTemplate;
+
 use crate::EvtxChunk;
 use crate::binxml::tokens::read_template_definition;
 use std::io::{Cursor, Seek, SeekFrom};

--- a/src/binxml/assemble.rs
+++ b/src/binxml/assemble.rs
@@ -4,7 +4,7 @@ use crate::binxml::value_variant::BinXmlValue;
 use crate::model::deserialized::{BinXMLDeserializedTokens, BinXmlTemplate};
 use crate::model::xml::{XmlElementBuilder, XmlModel, XmlPIBuilder};
 use crate::xml_output::BinXmlOutput;
-use log::{trace, warn};
+use log::{trace, warn, debug};
 use std::borrow::{Cow};
 
 use std::mem;
@@ -269,7 +269,12 @@ fn expand_borrowed_template<'a>(
     template_cache: &'a TemplateCache<'a>,
     stack: &mut Vec<Cow<'a, BinXMLDeserializedTokens<'a>>>,
 ) {
-    let template_def = template_cache.get_template(template.template_def_offset).unwrap();
+    let template_def = if let Some(template_def) = template_cache.get_template(template.template_def_offset) {
+        template_def
+    } else {
+        warn!("Template in offset {} was not found in cache", template.template_def_offset);
+        return;
+    };
 
     for token in template_def.tokens.iter() {
         if let BinXMLDeserializedTokens::Substitution(ref substitution_descriptor) = token {
@@ -306,7 +311,13 @@ fn expand_owned_template<'a, 'b>(
     template_cache: &'a TemplateCache<'a>,
     stack: &mut Vec<Cow<'a, BinXMLDeserializedTokens<'a>>>,
 ) {
-    let template_def = template_cache.get_template(template.template_def_offset).unwrap();
+
+    let template_def = if let Some(template_def) = template_cache.get_template(template.template_def_offset) {
+        template_def
+    } else {
+        warn!("Template in offset {} was not found in cache", template.template_def_offset);
+        return;
+    };
 
     for token in template_def.tokens.iter() {
         if let BinXMLDeserializedTokens::Substitution(ref substitution_descriptor) = token {

--- a/src/binxml/assemble.rs
+++ b/src/binxml/assemble.rs
@@ -313,7 +313,7 @@ fn expand_template<'a>(
         let _ = cursor.seek(SeekFrom::Start(u64::from(template.template_def_offset)));
         let template_def = read_template_definition(&mut cursor, Some(chunk), chunk.settings.get_ansi_codec());
 
-        if let Ok((template_def, _)) = template_def {
+        if let Ok(template_def) = template_def {
             for token in template_def.tokens {
                 if let BinXMLDeserializedTokens::Substitution(ref substitution_descriptor) = token {
                     expand_token_substitution(&mut template, substitution_descriptor, chunk, stack)

--- a/src/binxml/deserializer.rs
+++ b/src/binxml/deserializer.rs
@@ -20,7 +20,7 @@ use crate::{
 
 use crate::evtx_chunk::EvtxChunk;
 use encoding::EncodingRef;
-use std::borrow::Cow;
+
 use std::io::Cursor;
 use std::mem;
 

--- a/src/binxml/deserializer.rs
+++ b/src/binxml/deserializer.rs
@@ -154,9 +154,9 @@ impl<'a> IterTokens<'a> {
             BinXMLRawToken::CloseStartElement => Ok(BinXMLDeserializedTokens::CloseStartElement),
             BinXMLRawToken::CloseEmptyElement => Ok(BinXMLDeserializedTokens::CloseEmptyElement),
             BinXMLRawToken::CloseElement => Ok(BinXMLDeserializedTokens::CloseElement),
-            BinXMLRawToken::Value => Ok(BinXMLDeserializedTokens::Value(Cow::Owned(
+            BinXMLRawToken::Value => Ok(BinXMLDeserializedTokens::Value(
                 BinXmlValue::from_binxml_stream(cursor, self.chunk, None, self.ansi_codec)?,
-            ))),
+            )),
             BinXMLRawToken::Attribute(_token_information) => Ok(
                 BinXMLDeserializedTokens::Attribute(read_attribute(cursor, self.chunk)?),
             ),

--- a/src/binxml/tokens.rs
+++ b/src/binxml/tokens.rs
@@ -20,7 +20,6 @@ use crate::evtx_chunk::EvtxChunk;
 use encoding::EncodingRef;
 use std::borrow::Cow;
 
-
 pub fn read_template<'a>(
     cursor: &mut Cursor<&'a [u8]>,
     chunk: Option<&'a EvtxChunk<'a>>,
@@ -36,12 +35,13 @@ pub fn read_template<'a>(
     if (cursor.position() as u32) == template_definition_data_offset {
         let template_header = read_template_definition_header(cursor)?;
 
-        trace!("Skipping {} an already read template", template_header.data_size);
+        trace!(
+            "Skipping {} an already read template",
+            template_header.data_size
+        );
 
         cursor
-            .seek(SeekFrom::Current(
-                i64::from(template_header.data_size),
-            ))
+            .seek(SeekFrom::Current(i64::from(template_header.data_size)))
             .map_err(|e| {
                 WrappedIoError::io_error_with_message(
                     e,
@@ -137,8 +137,9 @@ pub fn read_template<'a>(
     })
 }
 
-
-pub fn read_template_definition_header(cursor: &mut Cursor<&[u8]>) -> Result<BinXmlTemplateDefinitionHeader> {
+pub fn read_template_definition_header(
+    cursor: &mut Cursor<&[u8]>,
+) -> Result<BinXmlTemplateDefinitionHeader> {
     // If any of these fail we cannot reliably report the template information in error.
     let next_template_offset = try_read!(cursor, u32, "next_template_offset")?;
     let template_guid = try_read!(cursor, guid, "template_guid")?;
@@ -146,7 +147,7 @@ pub fn read_template_definition_header(cursor: &mut Cursor<&[u8]>) -> Result<Bin
     // except for the first 33 bytes of the template definition (above)
     let data_size = try_read!(cursor, u32, "template_data_size")?;
 
-    Ok(BinXmlTemplateDefinitionHeader{
+    Ok(BinXmlTemplateDefinitionHeader {
         next_template_offset,
         guid: template_guid,
         data_size,
@@ -169,14 +170,13 @@ pub fn read_template_definition<'a>(
         false,
         ansi_codec,
     ) {
-        Ok(tokens) => BinXMLTemplateDefinition {
-            header,
-            tokens,
-        },
-        Err(e) => return Err(DeserializationError::FailedToDeserializeTemplate {
-            template_id: header.guid,
-            source: Box::new(e),
-        }),
+        Ok(tokens) => BinXMLTemplateDefinition { header, tokens },
+        Err(e) => {
+            return Err(DeserializationError::FailedToDeserializeTemplate {
+                template_id: header.guid,
+                source: Box::new(e),
+            })
+        }
     };
 
     Ok(template)
@@ -236,7 +236,7 @@ pub fn read_processing_instruction_data<'a>(cursor: &mut Cursor<&[u8]>) -> Resul
     );
 
     let data = try_read!(cursor, len_prefixed_utf_16_str, "pi_data")?.unwrap_or(Cow::Borrowed(""));
-    trace!("PIData - {}", data, );
+    trace!("PIData - {}", data,);
     Ok(data)
 }
 
@@ -376,7 +376,7 @@ mod test {
                 }),
                 Attribute(BinXMLAttribute { name: n!("xmlns") }),
                 Value(BinXmlValue::StringType(
-                    "http://schemas.microsoft.com/win/2004/08/events/event".into()
+                    "http://schemas.microsoft.com/win/2004/08/events/event".into(),
                 )),
                 CloseStartElement,
                 OpenStartElement(BinXMLOpenStartElement {
@@ -557,9 +557,7 @@ mod test {
                     name: n!("Computer"),
                 }),
                 CloseStartElement,
-                Value(BinXmlValue::StringType(
-                    "37L4247F27-25".into()
-                )),
+                Value(BinXmlValue::StringType("37L4247F27-25".into())),
                 CloseElement,
                 OpenStartElement(BinXMLOpenStartElement {
                     data_size: 66,

--- a/src/binxml/tokens.rs
+++ b/src/binxml/tokens.rs
@@ -57,7 +57,7 @@ pub fn read_template<'a>(
                     )
                 })?;
         }
-        Cow::Borrowed(definition)
+        BinXMLTemplateDefinitionCow::Borrowed(definition)
     } else if template_definition_data_offset != cursor.position() as u32 {
         trace!(
             "Need to seek to offset {} to read template",
@@ -87,9 +87,9 @@ pub fn read_template<'a>(
                 )
             })?;
 
-        Cow::Owned(template_def)
+        BinXMLTemplateDefinitionCow::Owned(template_def)
     } else {
-        Cow::Owned(read_template_definition(cursor, chunk, ansi_codec)?)
+        BinXMLTemplateDefinitionCow::Owned(read_template_definition(cursor, chunk, ansi_codec)?)
     };
 
     let number_of_substitutions = try_read!(cursor, u32)?;

--- a/src/binxml/tokens.rs
+++ b/src/binxml/tokens.rs
@@ -19,7 +19,7 @@ use std::io::SeekFrom;
 use crate::evtx_chunk::EvtxChunk;
 use encoding::EncodingRef;
 use std::borrow::Cow;
-use crate::ChunkOffset;
+
 
 pub fn read_template<'a>(
     cursor: &mut Cursor<&'a [u8]>,

--- a/src/binxml/tokens.rs
+++ b/src/binxml/tokens.rs
@@ -169,7 +169,7 @@ pub fn read_template<'a>(
                     )
                 })?;
         }
-        substitution_array.push(value);
+        substitution_array.push(BinXMLDeserializedTokens::Value(value));
     }
 
     Ok(BinXmlTemplate {
@@ -401,9 +401,9 @@ mod test {
                     name: n!("Event"),
                 }),
                 Attribute(BinXMLAttribute { name: n!("xmlns") }),
-                Value(Cow::Owned(BinXmlValue::StringType(Cow::Borrowed(
-                    "http://schemas.microsoft.com/win/2004/08/events/event",
-                )))),
+                Value(BinXmlValue::StringType(
+                    "http://schemas.microsoft.com/win/2004/08/events/event".into()
+                )),
                 CloseStartElement,
                 OpenStartElement(BinXMLOpenStartElement {
                     data_size: 982,
@@ -583,9 +583,9 @@ mod test {
                     name: n!("Computer"),
                 }),
                 CloseStartElement,
-                Value(Cow::Owned(BinXmlValue::StringType(Cow::Borrowed(
-                    "37L4247F27-25",
-                )))),
+                Value(BinXmlValue::StringType(
+                    "37L4247F27-25".into()
+                )),
                 CloseElement,
                 OpenStartElement(BinXMLOpenStartElement {
                     data_size: 66,

--- a/src/binxml/tokens.rs
+++ b/src/binxml/tokens.rs
@@ -25,7 +25,7 @@ pub fn read_template<'a>(
     cursor: &mut Cursor<&'a [u8]>,
     chunk: Option<&'a EvtxChunk<'a>>,
     ansi_codec: EncodingRef,
-) -> Result<BinXmlTemplate<'a>> {
+) -> Result<BinXmlTemplateRef<'a>> {
     trace!("TemplateInstance at {}", cursor.position());
 
     let _ = try_read!(cursor, u8)?;
@@ -131,7 +131,7 @@ pub fn read_template<'a>(
         substitution_array.push(BinXMLDeserializedTokens::Value(value));
     }
 
-    Ok(BinXmlTemplate {
+    Ok(BinXmlTemplateRef {
         template_def_offset: template_definition_data_offset,
         substitution_array,
     })

--- a/src/binxml/tokens.rs
+++ b/src/binxml/tokens.rs
@@ -171,10 +171,10 @@ pub fn read_template_definition<'a>(
             data_size,
             tokens,
         },
-        Err(e) => Err(DeserializationError::FailedToDeserializeTemplate {
+        Err(e) => return Err(DeserializationError::FailedToDeserializeTemplate {
             template_id: template_guid,
             source: Box::new(e),
-        })?,
+        }),
     };
 
     Ok((template, next_template_offset))
@@ -338,7 +338,7 @@ mod test {
     use crate::binxml::value_variant::BinXmlValue;
     use crate::ensure_env_logger_initialized;
     use encoding::all::WINDOWS_1252;
-    use std::borrow::Cow;
+    
     use std::io::{Cursor, Seek, SeekFrom};
     use winstructs::guid::Guid;
 

--- a/src/evtx_chunk.rs
+++ b/src/evtx_chunk.rs
@@ -159,18 +159,7 @@ impl<'chunk> EvtxChunk<'chunk> {
     /// Return an iterator of records from the chunk.
     /// See `IterChunkRecords` for a more detailed explanation regarding the lifetime scopes of the
     /// resulting records.
-    ///
-    /// Note: You cannot pass a mutable reference to `EvtxChunk` and call `iter` on it somewhere else.
-    /// Instead you should pass a mutable reference to `EvtxChunkData`.
-    ///
-    /// This is because the lifetime of `self` here is stricter (larger than `'chunk`)
-    /// than it theoretically needs to be.
-    /// However, this is required in practice because of issues regarding covariance,
-    /// which are caused by extensive use of the `Cow` type within the template cache.
-    ///
-    /// https://github.com/rust-lang/rust/issues/59875
-    /// https://github.com/rust-lang/rust/issues/21726#issuecomment-71949910
-    pub fn iter<'a: 'chunk>(&'a mut self) -> IterChunkRecords<'a> {
+    pub fn iter(&mut self) -> IterChunkRecords {
         IterChunkRecords {
             settings: Arc::clone(&self.settings),
             chunk: self,

--- a/src/evtx_chunk.rs
+++ b/src/evtx_chunk.rs
@@ -18,7 +18,7 @@ use crate::ParserSettings;
 
 use byteorder::{LittleEndian, ReadBytesExt};
 use std::sync::Arc;
-use std::cell::RefCell;
+
 
 const EVTX_CHUNK_HEADER_SIZE: usize = 512;
 

--- a/src/evtx_chunk.rs
+++ b/src/evtx_chunk.rs
@@ -18,6 +18,7 @@ use crate::ParserSettings;
 
 use byteorder::{LittleEndian, ReadBytesExt};
 use std::sync::Arc;
+use std::cell::RefCell;
 
 const EVTX_CHUNK_HEADER_SIZE: usize = 512;
 
@@ -117,6 +118,7 @@ impl EvtxChunkData {
 /// All references are created together,
 /// and can be assume to live for the entire duration of the parsing phase.
 /// See more info about lifetimes in `IterChunkRecords`.
+#[derive(Debug)]
 pub struct EvtxChunk<'chunk> {
     pub data: &'chunk [u8],
     pub header: &'chunk EvtxChunkHeader,
@@ -125,7 +127,7 @@ pub struct EvtxChunk<'chunk> {
     // but in the future we might want to change that, so it's here.
     pub string_cache: StringCache,
 
-    pub template_table: TemplateCache<'chunk>,
+    pub template_table: RefCell<TemplateCache<'chunk>>,
 
     settings: Arc<ParserSettings>,
 }
@@ -151,7 +153,7 @@ impl<'chunk> EvtxChunk<'chunk> {
             header,
             data,
             string_cache,
-            template_table,
+            template_table: template_table.into(),
             settings,
         })
     }
@@ -159,7 +161,7 @@ impl<'chunk> EvtxChunk<'chunk> {
     /// Return an iterator of records from the chunk.
     /// See `IterChunkRecords` for a more detailed explanation regarding the lifetime scopes of the
     /// resulting records.
-    pub fn iter(&mut self) -> IterChunkRecords {
+    pub fn iter<'a: 'chunk>(&'a mut self) -> IterChunkRecords<'a> {
         IterChunkRecords {
             settings: Arc::clone(&self.settings),
             chunk: self,
@@ -267,6 +269,7 @@ impl<'a> Iterator for IterChunkRecords<'a> {
         }
 
         Some(Ok(EvtxRecord {
+            chunk: self.chunk,
             event_record_id: record_header.event_record_id,
             timestamp: record_header.timestamp,
             tokens,

--- a/src/evtx_chunk.rs
+++ b/src/evtx_chunk.rs
@@ -127,7 +127,7 @@ pub struct EvtxChunk<'chunk> {
     // but in the future we might want to change that, so it's here.
     pub string_cache: StringCache,
 
-    pub template_table: RefCell<TemplateCache<'chunk>>,
+    pub template_table: TemplateCache<'chunk>,
 
     settings: Arc<ParserSettings>,
 }
@@ -153,7 +153,7 @@ impl<'chunk> EvtxChunk<'chunk> {
             header,
             data,
             string_cache,
-            template_table: template_table.into(),
+            template_table,
             settings,
         })
     }
@@ -161,7 +161,7 @@ impl<'chunk> EvtxChunk<'chunk> {
     /// Return an iterator of records from the chunk.
     /// See `IterChunkRecords` for a more detailed explanation regarding the lifetime scopes of the
     /// resulting records.
-    pub fn iter<'a: 'chunk>(&'a mut self) -> IterChunkRecords<'a> {
+    pub fn iter(&mut self) -> IterChunkRecords {
         IterChunkRecords {
             settings: Arc::clone(&self.settings),
             chunk: self,

--- a/src/evtx_chunk.rs
+++ b/src/evtx_chunk.rs
@@ -190,8 +190,8 @@ impl<'chunk> EvtxChunk<'chunk> {
 ///
 /// The reason we only keep a single 'a lifetime (and not 'chunk as well) is because we don't
 /// care about the larger lifetime, and so it allows us to simplify the definition of the struct.
-pub struct IterChunkRecords<'chunk> {
-    chunk: &'chunk EvtxChunk<'chunk>,
+pub struct IterChunkRecords<'a> {
+    chunk: &'a EvtxChunk<'a>,
     offset_from_chunk_start: u64,
     exhausted: bool,
     settings: Arc<ParserSettings>,

--- a/src/evtx_chunk.rs
+++ b/src/evtx_chunk.rs
@@ -129,7 +129,7 @@ pub struct EvtxChunk<'chunk> {
 
     pub template_table: TemplateCache<'chunk>,
 
-    settings: Arc<ParserSettings>,
+    pub settings: Arc<ParserSettings>,
 }
 
 impl<'chunk> EvtxChunk<'chunk> {

--- a/src/evtx_chunk.rs
+++ b/src/evtx_chunk.rs
@@ -19,7 +19,6 @@ use crate::ParserSettings;
 use byteorder::{LittleEndian, ReadBytesExt};
 use std::sync::Arc;
 
-
 const EVTX_CHUNK_HEADER_SIZE: usize = 512;
 
 #[derive(Debug)]

--- a/src/evtx_record.rs
+++ b/src/evtx_record.rs
@@ -119,7 +119,7 @@ impl<'a> EvtxRecord<'a> {
         self.into_output(&mut output_builder)?;
 
         let data = String::from_utf8(output_builder.into_writer())
-            .map_err(|e| SerializationError::from(e))?;
+            .map_err(SerializationError::from)?;
 
         Ok(SerializedEvtxRecord {
             event_record_id,

--- a/src/evtx_record.rs
+++ b/src/evtx_record.rs
@@ -68,7 +68,7 @@ impl<'a> EvtxRecord<'a> {
     /// Consumes the record, processing it using the given `output_builder`.
     pub fn into_output<T: BinXmlOutput>(self, output_builder: &mut T) -> Result<()> {
         let event_record_id = self.event_record_id;
-        parse_tokens(self.tokens, &self.chunk.template_table.borrow(), output_builder).map_err(|e| EvtxError::FailedToParseRecord {
+        parse_tokens(self.tokens, &self.chunk.template_table, output_builder).map_err(|e| EvtxError::FailedToParseRecord {
             record_id: event_record_id,
             source: Box::new(e),
         })?;

--- a/src/evtx_record.rs
+++ b/src/evtx_record.rs
@@ -68,7 +68,7 @@ impl<'a> EvtxRecord<'a> {
     /// Consumes the record, processing it using the given `output_builder`.
     pub fn into_output<T: BinXmlOutput>(self, output_builder: &mut T) -> Result<()> {
         let event_record_id = self.event_record_id;
-        parse_tokens(self.tokens, &self.chunk.template_table, output_builder).map_err(|e| EvtxError::FailedToParseRecord {
+        parse_tokens(self.tokens, &self.chunk, output_builder).map_err(|e| EvtxError::FailedToParseRecord {
             record_id: event_record_id,
             source: Box::new(e),
         })?;

--- a/src/evtx_record.rs
+++ b/src/evtx_record.rs
@@ -5,7 +5,7 @@ use crate::err::{
 use crate::json_output::JsonOutput;
 use crate::model::deserialized::BinXMLDeserializedTokens;
 use crate::xml_output::{BinXmlOutput, XmlOutput};
-use crate::{ParserSettings, EvtxChunk};
+use crate::{EvtxChunk, ParserSettings};
 
 use byteorder::ReadBytesExt;
 use chrono::prelude::*;
@@ -68,9 +68,11 @@ impl<'a> EvtxRecord<'a> {
     /// Consumes the record, processing it using the given `output_builder`.
     pub fn into_output<T: BinXmlOutput>(self, output_builder: &mut T) -> Result<()> {
         let event_record_id = self.event_record_id;
-        parse_tokens(self.tokens, &self.chunk, output_builder).map_err(|e| EvtxError::FailedToParseRecord {
-            record_id: event_record_id,
-            source: Box::new(e),
+        parse_tokens(self.tokens, &self.chunk, output_builder).map_err(|e| {
+            EvtxError::FailedToParseRecord {
+                record_id: event_record_id,
+                source: Box::new(e),
+            }
         })?;
 
         Ok(())
@@ -118,8 +120,8 @@ impl<'a> EvtxRecord<'a> {
         let timestamp = self.timestamp;
         self.into_output(&mut output_builder)?;
 
-        let data = String::from_utf8(output_builder.into_writer())
-            .map_err(SerializationError::from)?;
+        let data =
+            String::from_utf8(output_builder.into_writer()).map_err(SerializationError::from)?;
 
         Ok(SerializedEvtxRecord {
             event_record_id,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -170,7 +170,7 @@ macro_rules! try_read {
     ($cursor: ident, null_terminated_utf_16_str, $name: expr) => {
         read_null_terminated_utf16_string($cursor)
             .map_err(|e| capture_context!($cursor, e, "null_terminated_utf_16_str", $name))
-            .map(|s| Cow::Owned(s))
+            .map(Cow::Owned)
     };
 
     ($cursor: ident, sid, $name: expr) => {

--- a/src/model/deserialized.rs
+++ b/src/model/deserialized.rs
@@ -50,9 +50,19 @@ pub struct BinXmlEntityReference<'a> {
     pub name: BinXmlName<'a>,
 }
 
+/// Use an custom impl of `Cow`, because `Cow` has invariance which causes lifetime problems.
+///
+/// https://github.com/rust-lang/rust/issues/59875
+/// https://github.com/rust-lang/rust/issues/21726#issuecomment-71949910
+#[derive(Debug, PartialOrd, PartialEq, Clone)]
+pub enum BinXMLTemplateDefinitionCow<'a> {
+    Owned(BinXMLTemplateDefinition<'a>),
+    Borrowed(&'a BinXMLTemplateDefinition<'a>),
+}
+
 #[derive(Debug, PartialOrd, PartialEq, Clone)]
 pub struct BinXmlTemplate<'a> {
-    pub definition: Cow<'a, BinXMLTemplateDefinition<'a>>,
+    pub definition: BinXMLTemplateDefinitionCow<'a>,
     pub substitution_array: Vec<BinXMLDeserializedTokens<'a>>,
 }
 

--- a/src/model/deserialized.rs
+++ b/src/model/deserialized.rs
@@ -39,10 +39,16 @@ pub struct BinXMLOpenStartElement<'a> {
 }
 
 #[derive(Debug, PartialOrd, PartialEq, Clone)]
-pub struct BinXMLTemplateDefinition<'a> {
-    pub next_template_offset: u32,
-    pub template_guid: Guid,
+pub struct BinXmlTemplateDefinitionHeader {
+    /// A pointer to the next template in the bucket.
+    pub next_template_offset: ChunkOffset,
+    pub  guid: Guid,
     pub data_size: u32,
+}
+
+#[derive(Debug, PartialOrd, PartialEq, Clone)]
+pub struct BinXMLTemplateDefinition<'a> {
+    pub header: BinXmlTemplateDefinitionHeader,
     pub tokens: Vec<BinXMLDeserializedTokens<'a>>,
 }
 

--- a/src/model/deserialized.rs
+++ b/src/model/deserialized.rs
@@ -4,6 +4,7 @@ use crate::binxml::value_variant::{BinXmlValue, BinXmlValueType};
 use std::borrow::Cow;
 
 use winstructs::guid::Guid;
+use crate::ChunkOffset;
 
 #[derive(Debug, PartialOrd, PartialEq, Clone)]
 pub enum BinXMLDeserializedTokens<'a> {
@@ -50,19 +51,9 @@ pub struct BinXmlEntityReference<'a> {
     pub name: BinXmlName<'a>,
 }
 
-/// Use an custom impl of `Cow`, because `Cow` has invariance which causes lifetime problems.
-///
-/// https://github.com/rust-lang/rust/issues/59875
-/// https://github.com/rust-lang/rust/issues/21726#issuecomment-71949910
-#[derive(Debug, PartialOrd, PartialEq, Clone)]
-pub enum BinXMLTemplateDefinitionCow<'a> {
-    Owned(BinXMLTemplateDefinition<'a>),
-    Borrowed(&'a BinXMLTemplateDefinition<'a>),
-}
-
 #[derive(Debug, PartialOrd, PartialEq, Clone)]
 pub struct BinXmlTemplate<'a> {
-    pub definition: BinXMLTemplateDefinitionCow<'a>,
+    pub template_def_offset: ChunkOffset,
     pub substitution_array: Vec<BinXMLDeserializedTokens<'a>>,
 }
 

--- a/src/model/deserialized.rs
+++ b/src/model/deserialized.rs
@@ -9,7 +9,7 @@ use crate::ChunkOffset;
 #[derive(Debug, PartialOrd, PartialEq, Clone)]
 pub enum BinXMLDeserializedTokens<'a> {
     FragmentHeader(BinXMLFragmentHeader),
-    TemplateInstance(BinXmlTemplate<'a>),
+    TemplateInstance(BinXmlTemplateRef<'a>),
     OpenStartElement(BinXMLOpenStartElement<'a>),
     AttributeList,
     Attribute(BinXMLAttribute<'a>),
@@ -58,7 +58,7 @@ pub struct BinXmlEntityReference<'a> {
 }
 
 #[derive(Debug, PartialOrd, PartialEq, Clone)]
-pub struct BinXmlTemplate<'a> {
+pub struct BinXmlTemplateRef<'a> {
     pub template_def_offset: ChunkOffset,
     pub substitution_array: Vec<BinXMLDeserializedTokens<'a>>,
 }

--- a/src/model/deserialized.rs
+++ b/src/model/deserialized.rs
@@ -3,8 +3,8 @@ use crate::binxml::value_variant::{BinXmlValue, BinXmlValueType};
 
 use std::borrow::Cow;
 
-use winstructs::guid::Guid;
 use crate::ChunkOffset;
+use winstructs::guid::Guid;
 
 #[derive(Debug, PartialOrd, PartialEq, Clone)]
 pub enum BinXMLDeserializedTokens<'a> {
@@ -42,7 +42,7 @@ pub struct BinXMLOpenStartElement<'a> {
 pub struct BinXmlTemplateDefinitionHeader {
     /// A pointer to the next template in the bucket.
     pub next_template_offset: ChunkOffset,
-    pub  guid: Guid,
+    pub guid: Guid,
     pub data_size: u32,
 }
 

--- a/src/model/deserialized.rs
+++ b/src/model/deserialized.rs
@@ -15,7 +15,7 @@ pub enum BinXMLDeserializedTokens<'a> {
     CloseStartElement,
     CloseEmptyElement,
     CloseElement,
-    Value(Cow<'a, BinXmlValue<'a>>),
+    Value(BinXmlValue<'a>),
     CDATASection,
     CharRef,
     EntityRef(BinXmlEntityReference<'a>),
@@ -53,7 +53,7 @@ pub struct BinXmlEntityReference<'a> {
 #[derive(Debug, PartialOrd, PartialEq, Clone)]
 pub struct BinXmlTemplate<'a> {
     pub definition: Cow<'a, BinXMLTemplateDefinition<'a>>,
-    pub substitution_array: Vec<BinXmlValue<'a>>,
+    pub substitution_array: Vec<BinXMLDeserializedTokens<'a>>,
 }
 
 #[derive(Debug, PartialOrd, PartialEq, Clone)]

--- a/src/template_cache.rs
+++ b/src/template_cache.rs
@@ -6,9 +6,9 @@ use crate::ChunkOffset;
 pub use byteorder::{LittleEndian, ReadBytesExt};
 
 use encoding::EncodingRef;
+use log::trace;
 use std::collections::HashMap;
 use std::io::{Cursor, Seek, SeekFrom};
-use log::trace;
 
 pub type CachedTemplate<'chunk> = BinXMLTemplateDefinition<'chunk>;
 

--- a/src/template_cache.rs
+++ b/src/template_cache.rs
@@ -41,11 +41,12 @@ impl<'chunk> TemplateCache<'chunk> {
 
             loop {
                 let table_offset = cursor.position();
-                let (definition, next_template_offset) = read_template_definition(&mut cursor, None, ansi_codec)?;
+                let definition = read_template_definition(&mut cursor, None, ansi_codec)?;
+                let next_template_offset = definition.header.next_template_offset;
 
                 cache.insert(table_offset as u32, definition);
 
-                trace!("Next TemplateInstance will be at {}", next_template_offset);
+                trace!("Next template will be at {}", next_template_offset);
 
                 if next_template_offset == 0 {
                     break;

--- a/src/template_cache.rs
+++ b/src/template_cache.rs
@@ -45,8 +45,16 @@ impl<'chunk> TemplateCache<'chunk> {
         Ok(TemplateCache(cache))
     }
 
+    pub fn has_template(&self, offset: ChunkOffset) -> bool {
+        self.0.get(&offset).is_some()
+    }
+
     pub fn get_template(&self, offset: ChunkOffset) -> Option<&CachedTemplate<'chunk>> {
         self.0.get(&offset)
+    }
+
+    pub fn insert_template(&mut self, offset: ChunkOffset, template: CachedTemplate<'chunk>) {
+        self.0.insert(offset, template);
     }
 
     pub fn len(&self) -> usize {


### PR DESCRIPTION
@omerbenamram read the spec again, and we decided to read the entire template cache upfront, increasing the "cache hits" for the templates (== always, unless the file is dirty).

Perf should be improved by about ~20%~ (5%-10%), and some `Cow`s and lifetime bound could be removed.