### PR TITLE
Feature/string cache improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = "1"
 log = { version = "^0.4", features = ["release_max_level_debug"] }
 winstructs = "0.3.0"
 # Optional for multithreading.
-rayon = { version = "1.2.1", optional = true }
+rayon = { version = "1.3.0", optional = true }
 
 # `evtx_dump` dependencies
 anyhow = { version = "1", optional = true}
@@ -56,6 +56,9 @@ tempfile = "3.1.0"
 # rexpect relies on unix process semantics, but it's only used for process interaction tests.
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
 rexpect = "0.3.0"
+
+[profile.release]
+debug = 1
 
 [build-dependencies]
 skeptic = "0.13.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,9 +57,6 @@ tempfile = "3.1.0"
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
 rexpect = "0.3.0"
 
-[profile.release]
-debug = 1
-
 [build-dependencies]
 skeptic = "0.13.4"
 

--- a/src/binxml/assemble.rs
+++ b/src/binxml/assemble.rs
@@ -215,8 +215,8 @@ pub fn create_record_model<'a>(
             }
             Cow::Borrowed(BinXMLDeserializedTokens::Value(value)) => {
                 trace!("BinXMLDeserializedTokens::Value(value) - {:?}", value);
-                if current_element.is_none() {
-                    match value {
+                match current_element {
+                    None => match value {
                         BinXmlValue::EvtXml => {
                             return Err(EvtxError::FailedToCreateRecordModel(
                                 "Call `expand_templates` before calling this function",
@@ -225,10 +225,10 @@ pub fn create_record_model<'a>(
                         _ => {
                             model.push(XmlModel::Value(Cow::Borrowed(value)));
                         }
+                    },
+                    Some(ref mut builder) => {
+                        builder.attribute_value(Cow::Borrowed(value))?;
                     }
-                }
-                if let Some(builder) = current_element.as_mut() {
-                    builder.attribute_value(Cow::Borrowed(value))?
                 }
             }
         }

--- a/src/binxml/assemble.rs
+++ b/src/binxml/assemble.rs
@@ -32,16 +32,18 @@ pub fn parse_tokens<'a, T: BinXmlOutput>(
         match owned_token {
             XmlModel::OpenElement(open_element) => {
                 stack.push(open_element);
-                visitor.visit_open_start_element(stack.last().ok_or(
+                visitor.visit_open_start_element(stack.last().ok_or_else(|| {
                     EvtxError::FailedToCreateRecordModel(
                         "Invalid parser state - expected stack to be non-empty",
-                    ),
-                )?)?;
+                    )
+                })?)?;
             }
             XmlModel::CloseElement => {
-                let close_element = stack.pop().ok_or(EvtxError::FailedToCreateRecordModel(
-                    "Invalid parser state - expected stack to be non-empty",
-                ))?;
+                let close_element = stack.pop().ok_or_else(|| {
+                    EvtxError::FailedToCreateRecordModel(
+                        "Invalid parser state - expected stack to be non-empty",
+                    )
+                })?;
                 visitor.visit_close_element(&close_element)?
             }
             XmlModel::Value(s) => visitor.visit_characters(&s)?,

--- a/src/binxml/deserializer.rs
+++ b/src/binxml/deserializer.rs
@@ -199,11 +199,8 @@ impl<'a> IterTokens<'a> {
         let offset_from_chunk_start = cursor.position();
 
         trace!(
-            "Offset `0x{:08x}`: Reading next token",
-            offset_from_chunk_start
-        );
-        trace!(
-            "need to read: {:?}, read so far: {}",
+            "Offset `0x{:08x}`: need to read: {:?}, read so far: {}",
+            offset_from_chunk_start,
             self.data_size,
             self.data_read_so_far
         );

--- a/src/binxml/deserializer.rs
+++ b/src/binxml/deserializer.rs
@@ -139,6 +139,7 @@ impl<'a> IterTokens<'a> {
                 Ok(BinXMLDeserializedTokens::OpenStartElement(
                     read_open_start_element(
                         cursor,
+                        self.chunk,
                         token_information.has_attributes,
                         self.is_inside_substitution,
                     )?,

--- a/src/binxml/deserializer.rs
+++ b/src/binxml/deserializer.rs
@@ -139,7 +139,6 @@ impl<'a> IterTokens<'a> {
                 Ok(BinXMLDeserializedTokens::OpenStartElement(
                     read_open_start_element(
                         cursor,
-                        self.chunk,
                         token_information.has_attributes,
                         self.is_inside_substitution,
                     )?,
@@ -151,9 +150,9 @@ impl<'a> IterTokens<'a> {
             BinXMLRawToken::Value => Ok(BinXMLDeserializedTokens::Value(
                 BinXmlValue::from_binxml_stream(cursor, self.chunk, None, self.ansi_codec)?,
             )),
-            BinXMLRawToken::Attribute(_token_information) => Ok(
-                BinXMLDeserializedTokens::Attribute(read_attribute(cursor, self.chunk)?),
-            ),
+            BinXMLRawToken::Attribute(_token_information) => {
+                Ok(BinXMLDeserializedTokens::Attribute(read_attribute(cursor)?))
+            }
             BinXMLRawToken::CDataSection => Err(DeserializationError::UnimplementedToken {
                 name: "CDataSection",
                 offset: cursor.position(),
@@ -163,10 +162,10 @@ impl<'a> IterTokens<'a> {
                 offset: cursor.position(),
             }),
             BinXMLRawToken::EntityReference => Ok(BinXMLDeserializedTokens::EntityRef(
-                read_entity_ref(cursor, self.chunk)?,
+                read_entity_ref(cursor)?,
             )),
             BinXMLRawToken::ProcessingInstructionTarget => Ok(BinXMLDeserializedTokens::PITarget(
-                read_processing_instruction_target(cursor, self.chunk)?,
+                read_processing_instruction_target(cursor)?,
             )),
             BinXMLRawToken::ProcessingInstructionData => Ok(BinXMLDeserializedTokens::PIData(
                 read_processing_instruction_data(cursor)?,

--- a/src/binxml/deserializer.rs
+++ b/src/binxml/deserializer.rs
@@ -91,12 +91,6 @@ impl<'a> BinXmlDeserializer<'a> {
         }
 
         let seek_ahead = iterator.cursor.position() - offset;
-
-        trace!(
-            "Position is {}, seeking {} bytes ahead",
-            cursor.position(),
-            seek_ahead
-        );
         cursor.seek(SeekFrom::Current(seek_ahead as i64))?;
 
         Ok(tokens)
@@ -199,10 +193,10 @@ impl<'a> IterTokens<'a> {
         let offset_from_chunk_start = cursor.position();
 
         trace!(
-            "Offset `0x{:08x}`: need to read: {:?}, read so far: {}",
-            offset_from_chunk_start,
-            self.data_size,
-            self.data_read_so_far
+            "Offset `0x{offset:08x} ({offset})`: need to read: {data:?}, read so far: {pos}",
+            offset = offset_from_chunk_start,
+            data = self.data_size,
+            pos = self.data_read_so_far
         );
 
         // Finished reading

--- a/src/binxml/name.rs
+++ b/src/binxml/name.rs
@@ -1,11 +1,10 @@
-use crate::err::{DeserializationResult as Result, WrappedIoError};
+use crate::err::DeserializationResult as Result;
 
 use crate::ChunkOffset;
 pub use byteorder::{LittleEndian, ReadBytesExt};
 
 use crate::utils::read_len_prefixed_utf16_string;
 
-use log::trace;
 use std::borrow::Cow;
 use std::io::{Cursor, Seek, SeekFrom};
 
@@ -13,125 +12,108 @@ use crate::evtx_chunk::EvtxChunk;
 use quick_xml::events::{BytesEnd, BytesStart};
 
 #[derive(Debug, PartialEq, PartialOrd, Clone)]
-pub struct BinXmlName<'a>(pub Cow<'a, str>);
+pub struct BinXmlName<'a> {
+    str: Cow<'a, str>,
+    data_size: u32,
+}
 
-pub type StringHashOffset = (String, u16, ChunkOffset);
+#[derive(Debug, PartialEq, PartialOrd, Clone)]
+pub(crate) struct BinXmlNameLink {
+    pub next_string: Option<ChunkOffset>,
+    pub hash: u16,
+}
+
+impl BinXmlNameLink {
+    pub fn from_stream(stream: &mut Cursor<&[u8]>) -> Result<Self> {
+        let next_string = try_read!(stream, u32)?;
+        let name_hash = try_read!(stream, u16, "name_hash")?;
+
+        Ok(BinXmlNameLink {
+            next_string: if next_string > 0 {
+                Some(next_string)
+            } else {
+                None
+            },
+            hash: name_hash,
+        })
+    }
+
+    pub fn data_size() -> ChunkOffset {
+        12
+    }
+}
 
 impl<'a> BinXmlName<'a> {
-    pub fn from_static_string(s: &'static str) -> Self {
-        BinXmlName(Cow::Borrowed(s))
+    #[cfg(test)]
+    pub(crate) fn from_str(s: &'a str) -> Self {
+        BinXmlName {
+            str: Cow::Borrowed(s),
+            data_size: 0,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_string(s: String) -> Self {
+        BinXmlName {
+            str: Cow::Owned(s),
+            data_size: 0,
+        }
     }
 
     pub fn from_binxml_stream(
         cursor: &mut Cursor<&'a [u8]>,
         chunk: Option<&'a EvtxChunk<'a>>,
-    ) -> Result<BinXmlName<'a>> {
+    ) -> Result<Self> {
         // Important!!
         // The "offset_from_start" refers to the offset where the name struct begins.
         let name_offset = try_read!(cursor, u32, "name_offset")?;
 
         // If name is cached, read it and seek ahead if needed.
-        if let Some((name, _, n_bytes_read)) =
-            chunk.and_then(|chunk| chunk.string_cache.get_string_and_hash(name_offset))
+        if let Some(name) =
+            chunk.and_then(|chunk| chunk.string_cache.get_cached_string(name_offset))
         {
             // Seek if needed
-            if name_offset == cursor.position() as u32 {
-                cursor
-                    .seek(SeekFrom::Current(i64::from(*n_bytes_read)))
-                    .map_err(|e| {
-                        WrappedIoError::io_error_with_message(
-                            e,
-                            "failed to seek back while reading name",
-                            cursor,
-                        )
-                    })?;
-            }
-            return Ok(BinXmlName(Cow::Borrowed(name)));
-        }
+            let position_after_string = cursor.position() + u64::from(name.data_size);
+            try_seek!(cursor, position_after_string, "Skip cached string")?;
 
-        let (name, _, _) = Self::from_stream_at_offset(cursor, name_offset)?;
-        Ok(BinXmlName(Cow::Owned(name)))
+            // This doesn't actually clone the string, just the reference and the `data_size`.
+            Ok(name.clone())
+        } else {
+            Self::from_stream(cursor)
+        }
     }
 
     /// Reads a tuple of (String, Hash, Offset) from a stream.
-    pub fn from_stream(cursor: &mut Cursor<&'a [u8]>) -> Result<StringHashOffset> {
+    pub fn from_stream(cursor: &mut Cursor<&'a [u8]>) -> Result<Self> {
         let position_before_read = cursor.position();
 
-        let _ = try_read!(cursor, u32)?;
-        let name_hash = try_read!(cursor, u16, "name_hash")?;
         let name = try_read!(cursor, len_prefixed_utf_16_str_nul_terminated, "name")?
             .unwrap_or(Cow::Borrowed(""));
 
         let position_after_read = cursor.position();
+        let data_size = (position_after_read - position_before_read) as ChunkOffset
+            + BinXmlNameLink::data_size();
 
-        Ok((
-            name.to_string(),
-            name_hash,
-            (position_after_read - position_before_read) as ChunkOffset,
-        ))
-    }
-
-    /// Reads a `BinXmlName` from a given offset, seeks if needed.
-    fn from_stream_at_offset(
-        cursor: &mut Cursor<&'a [u8]>,
-        offset: ChunkOffset,
-    ) -> Result<StringHashOffset> {
-        trace!(
-            "Offset {} - Reading name at offset {}.",
-            cursor.position(),
-            offset
-        );
-
-        if offset != cursor.position() as u32 {
-            trace!("Seeking to {}", offset);
-
-            let position_before_seek = cursor.position();
-            // TODO: Seeking would usually fail here, so we need to dump the context at the original offset.
-            cursor
-                .seek(SeekFrom::Start(u64::from(offset)))
-                .map_err(|e| {
-                    WrappedIoError::io_error_with_message(
-                        e,
-                        "failed to seek when reading name".to_string(),
-                        cursor,
-                    )
-                })?;
-
-            let (name, hash, n_bytes_read) = Self::from_stream(cursor)?;
-
-            trace!("Restoring cursor to {}", position_before_seek);
-            cursor
-                .seek(SeekFrom::Start(position_before_seek))
-                .map_err(|e| {
-                    WrappedIoError::io_error_with_message(
-                        e,
-                        "failed to seek when reading name".to_string(),
-                        cursor,
-                    )
-                })?;
-
-            Ok((name, hash, n_bytes_read))
-        } else {
-            trace!("Name is at current offset");
-            let (name, hash, n_bytes_read) = Self::from_stream(cursor)?;
-            Ok((name, hash, n_bytes_read))
-        }
+        Ok(BinXmlName {
+            str: name,
+            data_size,
+        })
     }
 
     pub fn as_str(&self) -> &str {
-        &self.0
+        &self.str
     }
 }
 
 impl<'a> Into<quick_xml::events::BytesStart<'a>> for &'a BinXmlName<'a> {
     fn into(self) -> BytesStart<'a> {
-        BytesStart::borrowed_name(self.0.as_bytes())
+        BytesStart::borrowed_name(self.as_str().as_bytes())
     }
 }
 
 impl<'a> Into<quick_xml::events::BytesEnd<'a>> for BinXmlName<'a> {
     fn into(self) -> BytesEnd<'a> {
-        let inner = self.0.as_bytes();
+        let inner = self.as_str().as_bytes();
         BytesEnd::owned(inner.to_vec())
     }
 }

--- a/src/binxml/name.rs
+++ b/src/binxml/name.rs
@@ -8,18 +8,16 @@ use crate::utils::read_len_prefixed_utf16_string;
 use std::borrow::Cow;
 use std::io::{Cursor, Seek, SeekFrom};
 
-use crate::evtx_chunk::EvtxChunk;
-use log::trace;
 use quick_xml::events::{BytesEnd, BytesStart};
 use serde::export::Formatter;
 use std::fmt;
 
-#[derive(Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Debug, PartialEq, PartialOrd, Clone, Hash)]
 pub struct BinXmlName<'a> {
     str: Cow<'a, str>,
 }
 
-#[derive(Debug, PartialOrd, PartialEq, Clone)]
+#[derive(Debug, PartialOrd, PartialEq, Clone, Hash)]
 pub struct BinXmlNameRef {
     pub offset: ChunkOffset,
 }

--- a/src/binxml/name.rs
+++ b/src/binxml/name.rs
@@ -84,10 +84,11 @@ impl<'a> BinXmlName<'a> {
         if let Some(name) =
             chunk.and_then(|chunk| chunk.string_cache.get_cached_string(name_offset))
         {
-            trace!("String cache hit");
             // Seek if needed
-            let position_after_string = cursor.position() + u64::from(name.data_size);
-            try_seek!(cursor, position_after_string, "Skip cached string")?;
+            if cursor.position() == u64::from(name_offset) {
+                let position_after_string = cursor.position() + u64::from(name.data_size);
+                try_seek!(cursor, position_after_string, "Skip cached string")?;
+            }
 
             // This doesn't actually clone the string, just the reference and the `data_size`.
             Ok(name.clone())

--- a/src/binxml/name.rs
+++ b/src/binxml/name.rs
@@ -84,6 +84,7 @@ impl<'a> BinXmlName<'a> {
         if let Some(name) =
             chunk.and_then(|chunk| chunk.string_cache.get_cached_string(name_offset))
         {
+            trace!("String cache hit");
             // Seek if needed
             let position_after_string = cursor.position() + u64::from(name.data_size);
             try_seek!(cursor, position_after_string, "Skip cached string")?;

--- a/src/binxml/name.rs
+++ b/src/binxml/name.rs
@@ -17,7 +17,6 @@ use std::fmt;
 #[derive(Debug, PartialEq, PartialOrd, Clone)]
 pub struct BinXmlName<'a> {
     str: Cow<'a, str>,
-    data_size: u32,
 }
 
 #[derive(Debug, PartialOrd, PartialEq, Clone)]
@@ -87,77 +86,22 @@ impl BinXmlNameRef {
 impl<'a> BinXmlName<'a> {
     #[cfg(test)]
     pub(crate) fn from_str(s: &'a str) -> Self {
-        let nul_terminator_sz = 4;
-
         BinXmlName {
             str: Cow::Borrowed(s),
-            data_size: (s.len() * 2 + nul_terminator_sz + BinXmlNameLink::data_size() as usize)
-                as u32,
         }
     }
 
     #[cfg(test)]
     pub(crate) fn from_string(s: String) -> Self {
-        BinXmlName {
-            str: Cow::Owned(s),
-            data_size: 0,
-        }
-    }
-
-    pub fn from_binxml_stream(
-        cursor: &mut Cursor<&'a [u8]>,
-        chunk: Option<&'a EvtxChunk<'a>>,
-    ) -> Result<Self> {
-        // Important!!
-        // The "offset_from_start" refers to the offset where the name struct begins.
-        let name_offset = try_read!(cursor, u32, "name_offset")?;
-
-        // If name is cached, read it and seek ahead if needed.
-        if let Some(name) =
-            chunk.and_then(|chunk| chunk.string_cache.get_cached_string(name_offset))
-        {
-            // Seek if needed
-            if cursor.position() == u64::from(name_offset) {
-                let position_after_string = cursor.position() + u64::from(name.data_size);
-                try_seek!(cursor, position_after_string, "Skip cached string")?;
-            }
-
-            // This doesn't actually clone the string, just the reference and the `data_size`.
-            Ok(name.clone())
-        } else {
-            let current_position = cursor.position();
-
-            if current_position != u64::from(name_offset) {
-                try_seek!(cursor, name_offset, "Seek to string")?;
-
-                let _ = BinXmlNameLink::from_stream(cursor)?;
-                let ret = Self::from_stream(cursor);
-
-                try_seek!(cursor, current_position, "Seek back after reading string")?;
-                ret
-            } else {
-                trace!("name is here");
-                let _ = BinXmlNameLink::from_stream(cursor)?;
-                Self::from_stream(cursor)
-            }
-        }
+        BinXmlName { str: Cow::Owned(s) }
     }
 
     /// Reads a tuple of (String, Hash, Offset) from a stream.
     pub fn from_stream(cursor: &mut Cursor<&'a [u8]>) -> Result<Self> {
-        let position_before_read = cursor.position();
-
         let name = try_read!(cursor, len_prefixed_utf_16_str_nul_terminated, "name")?
             .unwrap_or(Cow::Borrowed(""));
 
-        let position_after_read = cursor.position();
-        let data_size = (position_after_read - position_before_read) as ChunkOffset
-            + BinXmlNameLink::data_size();
-
-        Ok(BinXmlName {
-            str: name,
-            data_size,
-        })
+        Ok(BinXmlName { str: name })
     }
 
     pub fn as_str(&self) -> &str {

--- a/src/binxml/name.rs
+++ b/src/binxml/name.rs
@@ -55,9 +55,12 @@ impl BinXmlNameLink {
 impl<'a> BinXmlName<'a> {
     #[cfg(test)]
     pub(crate) fn from_str(s: &'a str) -> Self {
+        let nul_terminator_sz = 4;
+
         BinXmlName {
             str: Cow::Borrowed(s),
-            data_size: 0,
+            data_size: (s.len() * 2 + nul_terminator_sz + BinXmlNameLink::data_size() as usize)
+                as u32,
         }
     }
 

--- a/src/binxml/name.rs
+++ b/src/binxml/name.rs
@@ -5,7 +5,6 @@ pub use byteorder::{LittleEndian, ReadBytesExt};
 
 use crate::utils::read_len_prefixed_utf16_string;
 
-use std::borrow::Cow;
 use std::io::{Cursor, Seek, SeekFrom};
 
 use quick_xml::events::{BytesEnd, BytesStart};

--- a/src/binxml/tokens.rs
+++ b/src/binxml/tokens.rs
@@ -322,6 +322,7 @@ pub fn read_open_start_element<'a>(
 
     trace!("\t Data Size - {}", data_size);
     let name = BinXmlName::from_binxml_stream(cursor, chunk)?;
+    trace!("\t Name - {}", name);
 
     let _attribute_list_data_size = if has_attributes {
         try_read!(cursor, u32, "open_start_element_attribute_list_data_size")?

--- a/src/binxml/tokens.rs
+++ b/src/binxml/tokens.rs
@@ -161,7 +161,11 @@ pub fn read_template_definition<'a>(
 ) -> Result<BinXMLTemplateDefinition<'a>> {
     let header = read_template_definition_header(cursor)?;
 
-    trace!("Read template header {:?}", header);
+    trace!(
+        "Offset `0x{:08x}` - TemplateDefinition {}",
+        cursor.position(),
+        header
+    );
 
     let template = match BinXmlDeserializer::read_binxml_fragment(
         cursor,
@@ -346,7 +350,7 @@ mod test {
 
     macro_rules! n {
         ($s: expr) => {
-            BinXmlName::from_static_string($s)
+            BinXmlName::from_str($s)
         };
     }
 

--- a/src/binxml/tokens.rs
+++ b/src/binxml/tokens.rs
@@ -7,7 +7,7 @@ use crate::model::deserialized::*;
 use std::io::Cursor;
 
 use crate::binxml::deserializer::BinXmlDeserializer;
-use crate::binxml::name::{BinXmlNameRef};
+use crate::binxml::name::BinXmlNameRef;
 use crate::binxml::value_variant::{BinXmlValue, BinXmlValueType};
 use crate::utils::read_len_prefixed_utf16_string;
 
@@ -204,13 +204,14 @@ pub fn read_processing_instruction_target(
     Ok(BinXMLProcessingInstructionTarget { name })
 }
 
-pub fn read_processing_instruction_data<'a>(cursor: &mut Cursor<&[u8]>) -> Result<Cow<'a, str>> {
+pub fn read_processing_instruction_data(cursor: &mut Cursor<&[u8]>) -> Result<String> {
     trace!(
         "Offset `0x{:08x}` - ProcessingInstructionTarget",
         cursor.position(),
     );
 
-    let data = try_read!(cursor, len_prefixed_utf_16_str, "pi_data")?.unwrap_or(Cow::Borrowed(""));
+    let data =
+        try_read!(cursor, len_prefixed_utf_16_str, "pi_data")?.unwrap_or_else(|| "".to_string());
     trace!("PIData - {}", data,);
     Ok(data)
 }

--- a/src/binxml/tokens.rs
+++ b/src/binxml/tokens.rs
@@ -7,7 +7,7 @@ use crate::model::deserialized::*;
 use std::io::Cursor;
 
 use crate::binxml::deserializer::BinXmlDeserializer;
-use crate::binxml::name::{BinXmlName, BinXmlNameRef};
+use crate::binxml::name::{BinXmlNameRef};
 use crate::binxml::value_variant::{BinXmlValue, BinXmlValueType};
 use crate::utils::read_len_prefixed_utf16_string;
 

--- a/src/binxml/tokens.rs
+++ b/src/binxml/tokens.rs
@@ -18,7 +18,6 @@ use std::io::SeekFrom;
 
 use crate::evtx_chunk::EvtxChunk;
 use encoding::EncodingRef;
-use std::borrow::Cow;
 
 pub fn read_template<'a>(
     cursor: &mut Cursor<&'a [u8]>,

--- a/src/binxml/tokens.rs
+++ b/src/binxml/tokens.rs
@@ -245,6 +245,7 @@ pub fn read_substitution_descriptor(
 
 pub fn read_open_start_element(
     cursor: &mut Cursor<&[u8]>,
+    chunk: Option<&EvtxChunk>,
     has_attributes: bool,
     is_substitution: bool,
 ) -> Result<BinXMLOpenStartElement> {
@@ -273,24 +274,22 @@ pub fn read_open_start_element(
     // This is a heuristic, sometimes `dependency_identifier` is not present even though it should have been.
     // This will result in interpreting garbage bytes as the data size.
     // We try to recover from this situation by rolling back the cursor and trying again, without reading the `dependency_identifier`.
-
-    // TODO: See if this can be fixed without the chunk
-    //    if let Some(c) = chunk {
-    //        if data_size >= c.data.len() as u32 {
-    //            warn!(
-    //                "Detected a case where `dependency_identifier` should not have been read. \
-    //                 Trying to read again without it."
-    //            );
-    //            cursor.seek(SeekFrom::Current(-6)).map_err(|e| {
-    //                WrappedIoError::io_error_with_message(
-    //                    e,
-    //                    "failed to skip when recovering from `dependency_identifier` hueristic",
-    //                    cursor,
-    //                )
-    //            })?;
-    //            return read_open_start_element(cursor, has_attributes, true);
-    //        }
-    //    }
+    if let Some(c) = chunk {
+        if data_size >= c.data.len() as u32 {
+            warn!(
+                "Detected a case where `dependency_identifier` should not have been read. \
+                 Trying to read again without it."
+            );
+            cursor.seek(SeekFrom::Current(-6)).map_err(|e| {
+                WrappedIoError::io_error_with_message(
+                    e,
+                    "failed to skip when recovering from `dependency_identifier` hueristic",
+                    cursor,
+                )
+            })?;
+            return read_open_start_element(cursor, chunk, has_attributes, true);
+        }
+    }
 
     trace!("\t Data Size - {}", data_size);
     let name = BinXmlNameRef::from_stream(cursor)?;

--- a/src/binxml/value_variant.rs
+++ b/src/binxml/value_variant.rs
@@ -213,7 +213,12 @@ impl<'a> BinXmlValue<'a> {
         size: Option<u16>,
         ansi_codec: EncodingRef,
     ) -> Result<BinXmlValue<'a>> {
-        trace!("deserialize_value_type: {:?}, {:?}", value_type, size);
+        trace!(
+            "Offset `0x{offset:08x} ({offset}): {value_type:?}, {size:?}",
+            offset = cursor.position(),
+            value_type = value_type,
+            size = size
+        );
 
         let value = match (value_type, size) {
             (BinXmlValueType::NullType, _) => BinXmlValue::NullType,

--- a/src/binxml/value_variant.rs
+++ b/src/binxml/value_variant.rs
@@ -27,7 +27,7 @@ use std::fmt::Write;
 pub enum BinXmlValue<'a> {
     NullType,
     // String may originate in substitution.
-    StringType(Cow<'a, str>),
+    StringType(String),
     AnsiStringType(Cow<'a, str>),
     Int8Type(i8),
     UInt8Type(u8),
@@ -52,7 +52,7 @@ pub enum BinXmlValue<'a> {
     // Because of the recursive type, we instantiate this enum via a method of the Deserializer
     BinXmlType(Vec<BinXMLDeserializedTokens<'a>>),
     EvtXml,
-    StringArrayType(Vec<Cow<'a, str>>),
+    StringArrayType(Vec<String>),
     AnsiStringArrayType,
     Int8ArrayType(Vec<i8>),
     UInt8ArrayType(Vec<u8>),
@@ -222,7 +222,7 @@ impl<'a> BinXmlValue<'a> {
 
         let value = match (value_type, size) {
             (BinXmlValueType::NullType, _) => BinXmlValue::NullType,
-            (BinXmlValueType::StringType, Some(sz)) => BinXmlValue::StringType(Cow::Owned(
+            (BinXmlValueType::StringType, Some(sz)) => BinXmlValue::StringType(
                 read_utf16_by_size(cursor, u64::from(sz))
                     .map_err(|e| {
                         WrappedIoError::io_error_with_message(
@@ -232,10 +232,10 @@ impl<'a> BinXmlValue<'a> {
                         )
                     })?
                     .unwrap_or_else(|| "".to_owned()),
-            )),
+            ),
             (BinXmlValueType::StringType, None) => BinXmlValue::StringType(
                 try_read!(cursor, len_prefixed_utf_16_str, "<string_value>")?
-                    .unwrap_or(Cow::Borrowed("")),
+                    .unwrap_or_else(|| "".to_string()),
             ),
             (BinXmlValueType::AnsiStringType, Some(sz)) => BinXmlValue::AnsiStringType(Cow::Owned(
                 read_ansi_encoded_string(cursor, u64::from(sz), ansi_codec)?
@@ -406,7 +406,7 @@ impl<'c> Into<serde_json::Value> for BinXmlValue<'c> {
     fn into(self) -> Value {
         match self {
             BinXmlValue::NullType => Value::Null,
-            BinXmlValue::StringType(s) => json!(s.into_owned()),
+            BinXmlValue::StringType(s) => json!(s),
             BinXmlValue::AnsiStringType(s) => json!(s.into_owned()),
             BinXmlValue::Int8Type(num) => json!(num),
             BinXmlValue::UInt8Type(num) => json!(num),
@@ -469,7 +469,7 @@ impl<'c> Into<serde_json::Value> for &'c BinXmlValue<'c> {
     fn into(self) -> Value {
         match self {
             BinXmlValue::NullType => Value::Null,
-            BinXmlValue::StringType(s) => json!(s.as_ref()),
+            BinXmlValue::StringType(s) => json!(s),
             BinXmlValue::AnsiStringType(s) => json!(s.as_ref()),
             BinXmlValue::Int8Type(num) => json!(num),
             BinXmlValue::UInt8Type(num) => json!(num),

--- a/src/evtx_chunk.rs
+++ b/src/evtx_chunk.rs
@@ -124,7 +124,7 @@ pub struct EvtxChunk<'chunk> {
 
     // For now, `StringCache` does not reference the `chunk lifetime,
     // but in the future we might want to change that, so it's here.
-    pub string_cache: StringCache,
+    pub string_cache: StringCache<'chunk>,
 
     pub template_table: TemplateCache<'chunk>,
 

--- a/src/evtx_chunk.rs
+++ b/src/evtx_chunk.rs
@@ -32,6 +32,15 @@ pub struct EvtxChunkHeader {
     pub free_space_offset: u32,
     pub events_checksum: u32,
     pub header_chunk_checksum: u32,
+    // A list of buckets containing the offsets of all strings in the chunk.
+    // Each bucket contains an initial offset for a `BinXmlNameLink`, which in turn contains
+    // the offset for the next strings.
+    // Empty buckets are given the value 0.
+    //  ----------       ------------------
+    // |          |     |                  |
+    // |  offset  | --> |  BinXmlNameLink  | ---> 0
+    // |          |     |                  |
+    //  ----------       ------------------
     strings_offsets: Vec<u32>,
     template_offsets: Vec<u32>,
 }
@@ -121,9 +130,6 @@ impl EvtxChunkData {
 pub struct EvtxChunk<'chunk> {
     pub data: &'chunk [u8],
     pub header: &'chunk EvtxChunkHeader,
-
-    // For now, `StringCache` does not reference the `chunk lifetime,
-    // but in the future we might want to change that, so it's here.
     pub string_cache: StringCache<'chunk>,
     pub template_table: TemplateCache<'chunk>,
 

--- a/src/evtx_chunk.rs
+++ b/src/evtx_chunk.rs
@@ -125,7 +125,6 @@ pub struct EvtxChunk<'chunk> {
     // For now, `StringCache` does not reference the `chunk lifetime,
     // but in the future we might want to change that, so it's here.
     pub string_cache: StringCache<'chunk>,
-
     pub template_table: TemplateCache<'chunk>,
 
     pub settings: Arc<ParserSettings>,

--- a/src/evtx_chunk.rs
+++ b/src/evtx_chunk.rs
@@ -130,7 +130,7 @@ impl EvtxChunkData {
 pub struct EvtxChunk<'chunk> {
     pub data: &'chunk [u8],
     pub header: &'chunk EvtxChunkHeader,
-    pub string_cache: StringCache<'chunk>,
+    pub string_cache: StringCache,
     pub template_table: TemplateCache<'chunk>,
 
     pub settings: Arc<ParserSettings>,

--- a/src/evtx_parser.rs
+++ b/src/evtx_parser.rs
@@ -512,25 +512,31 @@ mod tests {
 
     use super::*;
     use crate::ensure_env_logger_initialized;
+    use anyhow::anyhow;
 
-    fn process_90_records(buffer: &'static [u8]) {
-        let mut parser = EvtxParser::from_buffer(buffer.to_vec()).unwrap();
+    fn process_90_records(buffer: &'static [u8]) -> anyhow::Result<()> {
+        let mut parser = EvtxParser::from_buffer(buffer.to_vec())?;
 
         for (i, record) in parser.records().take(90).enumerate() {
             match record {
                 Ok(r) => {
                     assert_eq!(r.event_record_id, i as u64 + 1);
                 }
-                Err(e) => println!("Error while reading record {}, {:?}", i, e),
+                Err(e) => return Err(anyhow!("Error while reading record {}, {:?}", i, e)),
             }
         }
+
+        Ok(())
     }
 
     // For clion profiler
     #[test]
-    fn test_process_single_chunk() {
+    fn test_process_single_chunk() -> anyhow::Result<()> {
+        ensure_env_logger_initialized();
         let evtx_file = include_bytes!("../samples/security.evtx");
-        process_90_records(evtx_file);
+        process_90_records(evtx_file)?;
+
+        Ok(())
     }
 
     #[test]

--- a/src/json_output.rs
+++ b/src/json_output.rs
@@ -106,7 +106,7 @@ impl JsonOutput {
         match element
             .attributes
             .iter()
-            .find(|a| a.name.as_ref().0 == "Name")
+            .find(|a| a.name.as_ref().as_str() == "Name")
         {
             Some(name) => {
                 let data_key: Cow<'_, str> = name.value.as_ref().as_cow_str();
@@ -218,7 +218,7 @@ impl JsonOutput {
                 })?;
 
                 value.insert(format!("{}_attributes", name), Value::Object(attributes));
-                
+
                 // If the element's main value is empty, we want to remove it because we
                 // do not want the value to represent an empty object.
                 if value[name] == Value::Object(Map::new()) {
@@ -408,7 +408,7 @@ mod tests {
 
     fn dummy_event() -> XmlElement<'static> {
         XmlElement {
-            name: Cow::Owned(BinXmlName(Cow::Borrowed("Dummy"))),
+            name: Cow::Owned(BinXmlName::from_str("Dummy")),
             attributes: vec![],
         }
     }
@@ -419,7 +419,7 @@ mod tests {
         for attr in event.attributes() {
             let attr = attr.expect("Failed to read attribute.");
             attrs.push(XmlAttribute {
-                name: Cow::Owned(BinXmlName(Cow::Owned(bytes_to_string(attr.key)))),
+                name: Cow::Owned(BinXmlName::from_string(bytes_to_string(attr.key))),
                 // We have to compromise here and assume all values are strings.
                 value: Cow::Owned(BinXmlValue::StringType(Cow::Owned(bytes_to_string(
                     &attr.value,
@@ -428,7 +428,7 @@ mod tests {
         }
 
         XmlElement {
-            name: Cow::Owned(BinXmlName(Cow::Owned(bytes_to_string(event.name())))),
+            name: Cow::Owned(BinXmlName::from_string(bytes_to_string(event.name()))),
             attributes: attrs,
         }
     }

--- a/src/json_output.rs
+++ b/src/json_output.rs
@@ -361,7 +361,7 @@ impl BinXmlOutput for JsonOutput {
                 let as_string = String::from_utf8(escaped.to_vec())
                     .expect("This cannot fail, since it was a valid string beforehand");
 
-                self.visit_characters(&BinXmlValue::StringType(Cow::Borrowed(&as_string)))?;
+                self.visit_characters(&BinXmlValue::StringType(as_string))?;
                 Ok(())
             }
             Err(_) => Err(JsonStructureError {
@@ -421,9 +421,7 @@ mod tests {
             attrs.push(XmlAttribute {
                 name: Cow::Owned(BinXmlName::from_string(bytes_to_string(attr.key))),
                 // We have to compromise here and assume all values are strings.
-                value: Cow::Owned(BinXmlValue::StringType(Cow::Owned(bytes_to_string(
-                    &attr.value,
-                )))),
+                value: Cow::Owned(BinXmlValue::StringType(bytes_to_string(&attr.value))),
             });
         }
 
@@ -464,9 +462,7 @@ mod tests {
                             .expect("Empty Close");
                     }
                     Event::Text(text) => output
-                        .visit_characters(&BinXmlValue::StringType(Cow::Owned(bytes_to_string(
-                            text.as_ref(),
-                        ))))
+                        .visit_characters(&BinXmlValue::StringType(bytes_to_string(text.as_ref())))
                         .expect("Text element"),
                     Event::Comment(_) => {}
                     Event::CData(_) => unimplemented!(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,5 +42,12 @@ static LOGGER_INIT: Once = Once::new();
 // it will crash when attempting to run `cargo test` with some logging facilities.
 #[cfg(test)]
 pub fn ensure_env_logger_initialized() {
-    LOGGER_INIT.call_once(env_logger::init);
+    use std::io::Write;
+
+    LOGGER_INIT.call_once(|| {
+        let mut builder = env_logger::Builder::from_default_env();
+        builder
+            .format(|buf, record| writeln!(buf, "[{}] - {}", record.level(), record.args()))
+            .init();
+    });
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,4 +1,8 @@
 macro_rules! capture_context {
+    ($cursor: ident, $e: ident, $name: expr) => {{
+        let inner = $crate::err::WrappedIoError::capture_hexdump(Box::new($e), $cursor);
+        $crate::err::DeserializationError::from(inner)
+    }};
     ($cursor: ident, $e: ident, $token: expr, $name: expr) => {{
         let inner = $crate::err::WrappedIoError::capture_hexdump(Box::new($e), $cursor);
         $crate::err::DeserializationError::FailedToReadToken {
@@ -7,6 +11,14 @@ macro_rules! capture_context {
             source: inner,
         }
     }};
+}
+
+macro_rules! try_seek {
+    ($cursor: ident, $offset: expr, $name: expr) => {
+        $cursor
+            .seek(SeekFrom::Start(u64::from($offset.clone())))
+            .map_err(|e| capture_context!($cursor, e, $name));
+    };
 }
 
 /// Tries to read X bytes from the cursor, if reading fails, captures position nicely.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -154,10 +154,6 @@ macro_rules! try_read {
     ($cursor: ident, len_prefixed_utf_16_str, $name: expr) => {
         read_len_prefixed_utf16_string($cursor, false)
             .map_err(|e| capture_context!($cursor, e, "len_prefixed_utf_16_str", $name))
-            .map(|s| match s {
-                Some(s) => Some(Cow::Owned(s)),
-                None => None,
-            })
     };
 
     ($cursor: ident, len_prefixed_utf_16_str_nul_terminated) => {{
@@ -165,14 +161,9 @@ macro_rules! try_read {
     }};
 
     ($cursor: ident, len_prefixed_utf_16_str_nul_terminated, $name: expr) => {
-        read_len_prefixed_utf16_string($cursor, true)
-            .map_err(|e| {
-                capture_context!($cursor, e, "len_prefixed_utf_16_str_nul_terminated", $name)
-            })
-            .map(|s| match s {
-                Some(s) => Some(Cow::Owned(s)),
-                None => None,
-            })
+        read_len_prefixed_utf16_string($cursor, true).map_err(|e| {
+            capture_context!($cursor, e, "len_prefixed_utf_16_str_nul_terminated", $name)
+        })
     };
 
     ($cursor: ident, null_terminated_utf_16_str) => {{
@@ -182,7 +173,6 @@ macro_rules! try_read {
     ($cursor: ident, null_terminated_utf_16_str, $name: expr) => {
         read_null_terminated_utf16_string($cursor)
             .map_err(|e| capture_context!($cursor, e, "null_terminated_utf_16_str", $name))
-            .map(Cow::Owned)
     };
 
     ($cursor: ident, sid, $name: expr) => {

--- a/src/model/deserialized.rs
+++ b/src/model/deserialized.rs
@@ -1,4 +1,4 @@
-use crate::binxml::name::{BinXmlName, BinXmlNameRef};
+use crate::binxml::name::{BinXmlNameRef};
 use crate::binxml::value_variant::{BinXmlValue, BinXmlValueType};
 
 use std::borrow::Cow;

--- a/src/model/deserialized.rs
+++ b/src/model/deserialized.rs
@@ -1,8 +1,6 @@
 use crate::binxml::name::BinXmlNameRef;
 use crate::binxml::value_variant::{BinXmlValue, BinXmlValueType};
 
-use std::borrow::Cow;
-
 use crate::ChunkOffset;
 use serde::export::Formatter;
 use std::fmt;

--- a/src/model/deserialized.rs
+++ b/src/model/deserialized.rs
@@ -4,7 +4,6 @@ use crate::binxml::value_variant::{BinXmlValue, BinXmlValueType};
 use std::borrow::Cow;
 
 use crate::ChunkOffset;
-use serde::export::fmt::Error;
 use serde::export::Formatter;
 use std::fmt;
 use winstructs::guid::Guid;

--- a/src/model/deserialized.rs
+++ b/src/model/deserialized.rs
@@ -4,6 +4,9 @@ use crate::binxml::value_variant::{BinXmlValue, BinXmlValueType};
 use std::borrow::Cow;
 
 use crate::ChunkOffset;
+use serde::export::fmt::Error;
+use serde::export::Formatter;
+use std::fmt;
 use winstructs::guid::Guid;
 
 #[derive(Debug, PartialOrd, PartialEq, Clone)]
@@ -44,6 +47,17 @@ pub struct BinXmlTemplateDefinitionHeader {
     pub next_template_offset: ChunkOffset,
     pub guid: Guid,
     pub data_size: u32,
+}
+
+impl fmt::Display for BinXmlTemplateDefinitionHeader {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "<BinXmlTemplateDefinitionHeader - id: {guid}, data_size: {size}>",
+            guid = self.guid.to_string(),
+            size = self.data_size
+        )
+    }
 }
 
 #[derive(Debug, PartialOrd, PartialEq, Clone)]

--- a/src/model/deserialized.rs
+++ b/src/model/deserialized.rs
@@ -1,4 +1,4 @@
-use crate::binxml::name::BinXmlName;
+use crate::binxml::name::{BinXmlName, BinXmlNameRef};
 use crate::binxml::value_variant::{BinXmlValue, BinXmlValueType};
 
 use std::borrow::Cow;
@@ -12,17 +12,17 @@ use winstructs::guid::Guid;
 pub enum BinXMLDeserializedTokens<'a> {
     FragmentHeader(BinXMLFragmentHeader),
     TemplateInstance(BinXmlTemplateRef<'a>),
-    OpenStartElement(BinXMLOpenStartElement<'a>),
+    OpenStartElement(BinXMLOpenStartElement),
     AttributeList,
-    Attribute(BinXMLAttribute<'a>),
+    Attribute(BinXMLAttribute),
     CloseStartElement,
     CloseEmptyElement,
     CloseElement,
     Value(BinXmlValue<'a>),
     CDATASection,
     CharRef,
-    EntityRef(BinXmlEntityReference<'a>),
-    PITarget(BinXMLProcessingInstructionTarget<'a>),
+    EntityRef(BinXmlEntityReference),
+    PITarget(BinXMLProcessingInstructionTarget),
     PIData(Cow<'a, str>),
     Substitution(TemplateSubstitutionDescriptor),
     EndOfStream,
@@ -30,14 +30,14 @@ pub enum BinXMLDeserializedTokens<'a> {
 }
 
 #[derive(Debug, PartialOrd, PartialEq, Clone)]
-pub struct BinXMLProcessingInstructionTarget<'a> {
-    pub name: BinXmlName<'a>,
+pub struct BinXMLProcessingInstructionTarget {
+    pub name: BinXmlNameRef,
 }
 
 #[derive(Debug, PartialOrd, PartialEq, Clone)]
-pub struct BinXMLOpenStartElement<'a> {
+pub struct BinXMLOpenStartElement {
     pub data_size: u32,
-    pub name: BinXmlName<'a>,
+    pub name: BinXmlNameRef,
 }
 
 #[derive(Debug, PartialOrd, PartialEq, Clone)]
@@ -66,8 +66,8 @@ pub struct BinXMLTemplateDefinition<'a> {
 }
 
 #[derive(Debug, PartialOrd, PartialEq, Clone)]
-pub struct BinXmlEntityReference<'a> {
-    pub name: BinXmlName<'a>,
+pub struct BinXmlEntityReference {
+    pub name: BinXmlNameRef,
 }
 
 #[derive(Debug, PartialOrd, PartialEq, Clone)]
@@ -99,6 +99,6 @@ pub struct BinXMLFragmentHeader {
 }
 
 #[derive(Debug, PartialOrd, PartialEq, Clone)]
-pub struct BinXMLAttribute<'a> {
-    pub name: BinXmlName<'a>,
+pub struct BinXMLAttribute {
+    pub name: BinXmlNameRef,
 }

--- a/src/model/deserialized.rs
+++ b/src/model/deserialized.rs
@@ -1,4 +1,4 @@
-use crate::binxml::name::{BinXmlNameRef};
+use crate::binxml::name::BinXmlNameRef;
 use crate::binxml::value_variant::{BinXmlValue, BinXmlValueType};
 
 use std::borrow::Cow;
@@ -23,7 +23,7 @@ pub enum BinXMLDeserializedTokens<'a> {
     CharRef,
     EntityRef(BinXmlEntityReference),
     PITarget(BinXMLProcessingInstructionTarget),
-    PIData(Cow<'a, str>),
+    PIData(String),
     Substitution(TemplateSubstitutionDescriptor),
     EndOfStream,
     StartOfStream,

--- a/src/model/xml.rs
+++ b/src/model/xml.rs
@@ -5,14 +5,12 @@ use crate::err::EvtxError;
 use log::error;
 use std::borrow::Cow;
 
-type Name<'a> = BinXmlName<'a>;
-
 #[derive(Debug, PartialOrd, PartialEq, Clone)]
 pub enum XmlModel<'a> {
     OpenElement(XmlElement<'a>),
     CloseElement,
     PI(BinXmlPI<'a>),
-    EntityRef(Cow<'a, Name<'a>>),
+    EntityRef(Cow<'a, BinXmlName>),
     Value(Cow<'a, BinXmlValue<'a>>),
     EndOfStream,
     StartOfStream,
@@ -20,9 +18,9 @@ pub enum XmlModel<'a> {
 
 #[derive(Debug)]
 pub(crate) struct XmlElementBuilder<'a> {
-    name: Option<Cow<'a, Name<'a>>>,
+    name: Option<Cow<'a, BinXmlName>>,
     attributes: Vec<XmlAttribute<'a>>,
-    current_attribute_name: Option<Cow<'a, Name<'a>>>,
+    current_attribute_name: Option<Cow<'a, BinXmlName>>,
     current_attribute_value: Option<Cow<'a, BinXmlValue<'a>>>,
 }
 
@@ -35,11 +33,11 @@ impl<'a> XmlElementBuilder<'a> {
             current_attribute_value: None,
         }
     }
-    pub fn name(&mut self, name: Cow<'a, Name<'a>>) {
+    pub fn name(&mut self, name: Cow<'a, BinXmlName>) {
         self.name = Some(name);
     }
 
-    pub fn attribute_name(&mut self, name: Cow<'a, Name<'a>>) {
+    pub fn attribute_name(&mut self, name: Cow<'a, BinXmlName>) {
         match self.current_attribute_name {
             None => self.current_attribute_name = Some(name),
             Some(_) => {
@@ -84,7 +82,7 @@ impl<'a> XmlElementBuilder<'a> {
 }
 
 pub(crate) struct XmlPIBuilder<'a> {
-    name: Option<Cow<'a, Name<'a>>>,
+    name: Option<Cow<'a, BinXmlName>>,
     data: Option<Cow<'a, str>>,
 }
 
@@ -95,14 +93,12 @@ impl<'a> XmlPIBuilder<'a> {
             data: None,
         }
     }
-    pub fn name(mut self, name: Cow<'a, Name<'a>>) -> Self {
+    pub fn name(&mut self, name: Cow<'a, BinXmlName>) {
         self.name = Some(name);
-        self
     }
 
-    pub fn data(mut self, data: Cow<'a, str>) -> Self {
+    pub fn data(&mut self, data: Cow<'a, str>) {
         self.data = Some(data);
-        self
     }
 
     pub fn finish(self) -> XmlModel<'a> {
@@ -115,18 +111,18 @@ impl<'a> XmlPIBuilder<'a> {
 
 #[derive(Debug, PartialOrd, PartialEq, Clone)]
 pub struct XmlAttribute<'a> {
-    pub name: Cow<'a, Name<'a>>,
+    pub name: Cow<'a, BinXmlName>,
     pub value: Cow<'a, BinXmlValue<'a>>,
 }
 
 #[derive(Debug, PartialOrd, PartialEq, Clone)]
 pub struct XmlElement<'a> {
-    pub name: Cow<'a, Name<'a>>,
+    pub name: Cow<'a, BinXmlName>,
     pub attributes: Vec<XmlAttribute<'a>>,
 }
 
 #[derive(Debug, PartialOrd, PartialEq, Clone)]
 pub struct BinXmlPI<'a> {
-    pub name: Cow<'a, Name<'a>>,
+    pub name: Cow<'a, BinXmlName>,
     pub data: Cow<'a, str>,
 }

--- a/src/model/xml.rs
+++ b/src/model/xml.rs
@@ -35,27 +35,25 @@ impl<'a> XmlElementBuilder<'a> {
             current_attribute_value: None,
         }
     }
-    pub fn name(mut self, name: Cow<'a, Name<'a>>) -> Self {
+    pub fn name(&mut self, name: Cow<'a, Name<'a>>) {
         self.name = Some(name);
-        self
     }
 
-    pub fn attribute_name(mut self, name: Cow<'a, Name<'a>>) -> Self {
+    pub fn attribute_name(&mut self, name: Cow<'a, Name<'a>>) {
         match self.current_attribute_name {
             None => self.current_attribute_name = Some(name),
-            Some(name) => {
+            Some(_) => {
                 error!("invalid state, overriding name");
                 self.current_attribute_name = Some(name);
             }
         }
-        self
     }
 
-    pub fn attribute_value(mut self, value: Cow<'a, BinXmlValue<'a>>) -> Result<Self, EvtxError> {
+    pub fn attribute_value(&mut self, value: Cow<'a, BinXmlValue<'a>>) -> Result<(), EvtxError> {
         // If we are in an attribute value without a name, simply ignore the request.
         // This is consistent with what windows is doing.
         if self.current_attribute_name.is_none() {
-            return Ok(self);
+            return Ok(());
         }
 
         match self.current_attribute_value {
@@ -72,7 +70,7 @@ impl<'a> XmlElementBuilder<'a> {
             value: self.current_attribute_value.take().unwrap(),
         });
 
-        Ok(self)
+        Ok(())
     }
 
     pub fn finish(self) -> Result<XmlElement<'a>, EvtxError> {

--- a/src/string_cache.rs
+++ b/src/string_cache.rs
@@ -1,43 +1,46 @@
-use crate::binxml::name::BinXmlName;
-use crate::err::{DeserializationResult, WrappedIoError};
+use crate::binxml::name::{BinXmlName, BinXmlNameLink};
+use crate::err::DeserializationResult;
 use crate::ChunkOffset;
 
+use log::trace;
+use std::borrow::BorrowMut;
 use std::collections::HashMap;
 use std::io::{Cursor, Seek, SeekFrom};
 
-pub type StringHash = u16;
+#[derive(Debug)]
+pub struct StringCache<'a>(HashMap<ChunkOffset, BinXmlName<'a>>);
 
-pub type CachedString = (String, StringHash, ChunkOffset);
-
-#[derive(Debug, Default)]
-pub struct StringCache(HashMap<ChunkOffset, CachedString>);
-
-impl StringCache {
-    pub fn populate(data: &[u8], offsets: &[ChunkOffset]) -> DeserializationResult<Self> {
+impl<'a> StringCache<'a> {
+    pub fn populate(data: &'a [u8], offsets: &[ChunkOffset]) -> DeserializationResult<Self> {
         let mut cache = HashMap::new();
-        let mut cursor = Cursor::new(data);
+        let mut temp_cursor = Cursor::new(data);
+        let cursor = temp_cursor.borrow_mut();
 
-        for offset in offsets.iter().filter(|&&offset| offset > 0) {
-            cursor
-                .seek(SeekFrom::Start(u64::from(*offset)))
-                .map_err(|e| {
-                    WrappedIoError::io_error_with_message(
-                        e,
-                        format!(
-                            "Failed to seek when trying to read string at offset: {}",
-                            offset
-                        ),
-                        &mut cursor,
-                    )
-                })?;
+        for &offset in offsets.iter().filter(|&&offset| offset > 0) {
+            try_seek!(cursor, offset, "first xml string")?;
 
-            cache.insert(*offset, BinXmlName::from_stream(&mut cursor)?);
+            loop {
+                let string_position = cursor.position() as ChunkOffset;
+                let link = BinXmlNameLink::from_stream(cursor)?;
+                let name = BinXmlName::from_stream(cursor)?;
+
+                cache.insert(string_position, name);
+
+                trace!("\tNext string will be at {:?}", link.next_string);
+
+                match link.next_string {
+                    Some(offset) => {
+                        try_seek!(cursor, offset, "next xml string")?;
+                    }
+                    None => break,
+                }
+            }
         }
 
         Ok(StringCache(cache))
     }
 
-    pub fn get_string_and_hash(&self, offset: ChunkOffset) -> Option<&CachedString> {
+    pub fn get_cached_string(&self, offset: ChunkOffset) -> Option<&BinXmlName<'a>> {
         self.0.get(&offset)
     }
 

--- a/src/string_cache.rs
+++ b/src/string_cache.rs
@@ -8,10 +8,10 @@ use std::collections::HashMap;
 use std::io::{Cursor, Seek, SeekFrom};
 
 #[derive(Debug)]
-pub struct StringCache<'a>(HashMap<ChunkOffset, BinXmlName<'a>>);
+pub struct StringCache(HashMap<ChunkOffset, BinXmlName>);
 
-impl<'a> StringCache<'a> {
-    pub fn populate(data: &'a [u8], offsets: &[ChunkOffset]) -> DeserializationResult<Self> {
+impl StringCache {
+    pub fn populate(data: &[u8], offsets: &[ChunkOffset]) -> DeserializationResult<Self> {
         let mut cache = HashMap::new();
         let mut temp_cursor = Cursor::new(data);
         let cursor = temp_cursor.borrow_mut();
@@ -40,7 +40,7 @@ impl<'a> StringCache<'a> {
         Ok(StringCache(cache))
     }
 
-    pub fn get_cached_string(&self, offset: ChunkOffset) -> Option<&BinXmlName<'a>> {
+    pub fn get_cached_string(&self, offset: ChunkOffset) -> Option<&BinXmlName> {
         self.0.get(&offset)
     }
 

--- a/src/string_cache.rs
+++ b/src/string_cache.rs
@@ -13,16 +13,16 @@ pub struct StringCache(HashMap<ChunkOffset, BinXmlName>);
 impl StringCache {
     pub fn populate(data: &[u8], offsets: &[ChunkOffset]) -> DeserializationResult<Self> {
         let mut cache = HashMap::new();
-        let mut temp_cursor = Cursor::new(data);
-        let cursor = temp_cursor.borrow_mut();
+        let mut cursor = Cursor::new(data);
+        let cursor_ref = cursor.borrow_mut();
 
         for &offset in offsets.iter().filter(|&&offset| offset > 0) {
-            try_seek!(cursor, offset, "first xml string")?;
+            try_seek!(cursor_ref, offset, "first xml string")?;
 
             loop {
-                let string_position = cursor.position() as ChunkOffset;
-                let link = BinXmlNameLink::from_stream(cursor)?;
-                let name = BinXmlName::from_stream(cursor)?;
+                let string_position = cursor_ref.position() as ChunkOffset;
+                let link = BinXmlNameLink::from_stream(cursor_ref)?;
+                let name = BinXmlName::from_stream(cursor_ref)?;
 
                 cache.insert(string_position, name);
 
@@ -30,7 +30,7 @@ impl StringCache {
 
                 match link.next_string {
                     Some(offset) => {
-                        try_seek!(cursor, offset, "next xml string")?;
+                        try_seek!(cursor_ref, offset, "next xml string")?;
                     }
                     None => break,
                 }

--- a/src/template_cache.rs
+++ b/src/template_cache.rs
@@ -46,7 +46,7 @@ impl<'chunk> TemplateCache<'chunk> {
                     break;
                 }
 
-                try_seek!(cursor, offset, "next template")?;
+                try_seek!(cursor, next_template_offset, "next template")?;
             }
         }
 

--- a/src/template_cache.rs
+++ b/src/template_cache.rs
@@ -27,15 +27,15 @@ impl<'chunk> TemplateCache<'chunk> {
         ansi_codec: EncodingRef,
     ) -> DeserializationResult<Self> {
         let mut cache = HashMap::new();
-        let mut temp_cursor = Cursor::new(data);
-        let cursor = temp_cursor.borrow_mut();
+        let mut cursor = Cursor::new(data);
+        let cursor_ref = cursor.borrow_mut();
 
         for offset in offsets.iter().filter(|&&offset| offset > 0) {
-            try_seek!(cursor, offset, "first template")?;
+            try_seek!(cursor_ref, offset, "first template")?;
 
             loop {
-                let table_offset = cursor.position() as ChunkOffset;
-                let definition = read_template_definition(cursor, None, ansi_codec)?;
+                let table_offset = cursor_ref.position() as ChunkOffset;
+                let definition = read_template_definition(cursor_ref, None, ansi_codec)?;
                 let next_template_offset = definition.header.next_template_offset;
 
                 cache.insert(table_offset, definition);
@@ -46,7 +46,7 @@ impl<'chunk> TemplateCache<'chunk> {
                     break;
                 }
 
-                try_seek!(cursor, next_template_offset, "next template")?;
+                try_seek!(cursor_ref, next_template_offset, "next template")?;
             }
         }
 

--- a/src/template_cache.rs
+++ b/src/template_cache.rs
@@ -1,5 +1,5 @@
 use crate::binxml::tokens::read_template_definition;
-use crate::err::{DeserializationResult, WrappedIoError};
+use crate::err::DeserializationResult;
 
 use crate::model::deserialized::BinXMLTemplateDefinition;
 use crate::ChunkOffset;
@@ -7,6 +7,7 @@ pub use byteorder::{LittleEndian, ReadBytesExt};
 
 use encoding::EncodingRef;
 use log::trace;
+use std::borrow::BorrowMut;
 use std::collections::HashMap;
 use std::io::{Cursor, Seek, SeekFrom};
 
@@ -26,25 +27,18 @@ impl<'chunk> TemplateCache<'chunk> {
         ansi_codec: EncodingRef,
     ) -> DeserializationResult<Self> {
         let mut cache = HashMap::new();
-        let mut cursor = Cursor::new(data);
+        let mut temp_cursor = Cursor::new(data);
+        let cursor = temp_cursor.borrow_mut();
 
         for offset in offsets.iter().filter(|&&offset| offset > 0) {
-            cursor
-                .seek(SeekFrom::Start(u64::from(*offset)))
-                .map_err(|e| {
-                    WrappedIoError::io_error_with_message(
-                        e,
-                        format!("seeking to template at chunk offset {} failed.", offset),
-                        &mut cursor,
-                    )
-                })?;
+            try_seek!(cursor, offset, "first template")?;
 
             loop {
-                let table_offset = cursor.position();
-                let definition = read_template_definition(&mut cursor, None, ansi_codec)?;
+                let table_offset = cursor.position() as ChunkOffset;
+                let definition = read_template_definition(cursor, None, ansi_codec)?;
                 let next_template_offset = definition.header.next_template_offset;
 
-                cache.insert(table_offset as u32, definition);
+                cache.insert(table_offset, definition);
 
                 trace!("Next template will be at {}", next_template_offset);
 
@@ -52,7 +46,7 @@ impl<'chunk> TemplateCache<'chunk> {
                     break;
                 }
 
-                cursor.seek(SeekFrom::Start(u64::from(next_template_offset)))?;
+                try_seek!(cursor, offset, "next template")?;
             }
         }
 

--- a/src/utils/binxml_utils.rs
+++ b/src/utils/binxml_utils.rs
@@ -25,13 +25,14 @@ pub fn read_len_prefixed_utf16_string<T: ReadSeek>(
     let needed_bytes = u64::from(expected_number_of_characters * 2);
 
     trace!(
-        "Going to read a{}string of len {} from stream",
-        if is_null_terminated {
+        "Offset `0x{offset:08x} ({offset})` reading a{nul}string of len {len}",
+        offset = stream.tell().unwrap_or(0),
+        nul = if is_null_terminated {
             " null terminated "
         } else {
             " "
         },
-        expected_number_of_characters
+        len = expected_number_of_characters
     );
 
     let s = read_utf16_by_size(stream, needed_bytes)?;

--- a/tests/fixtures.rs
+++ b/tests/fixtures.rs
@@ -7,8 +7,16 @@ static LOGGER_INIT: Once = Once::new();
 
 // Rust runs the tests concurrently, so unless we synchronize logging access
 // it will crash when attempting to run `cargo test` with some logging facilities.
+#[cfg(test)]
 pub fn ensure_env_logger_initialized() {
-    LOGGER_INIT.call_once(env_logger::init);
+    use std::io::Write;
+
+    LOGGER_INIT.call_once(|| {
+        let mut builder = env_logger::Builder::from_default_env();
+        builder
+            .format(|buf, record| writeln!(buf, "[{}] - {}", record.level(), record.args()))
+            .init();
+    });
 }
 
 pub fn samples_dir() -> PathBuf {

--- a/tests/test_record_separate_json.rs
+++ b/tests/test_record_separate_json.rs
@@ -15,7 +15,7 @@ fn test_event_json_with_multiple_nodes_same_name_separate() {
         .with_configuration(
             ParserSettings::new()
                 .num_threads(1)
-                .separate_json_attributes(true)
+                .separate_json_attributes(true),
         );
 
     let record = parser


### PR DESCRIPTION
Apparently utilizing cached string yield only a modest performance increast (<5%).
It does make some flow significatly simpler as all seeks are eliminated while reading the binxml data.