### PR TITLE
Provide public usable visitor interface

### DIFF
--- a/src/err.rs
+++ b/src/err.rs
@@ -181,6 +181,9 @@ pub enum SerializationError {
         source: std::string::FromUtf8Error,
     },
 
+    #[error("Generating an internal structure failed with message: {message}")]
+    StructureBuilderError {message: String },
+
     #[error("Unimplemented: {message}")]
     Unimplemented { message: String },
 }

--- a/src/evtx_parser.rs
+++ b/src/evtx_parser.rs
@@ -3,6 +3,8 @@ use crate::err::{ChunkError, EvtxError, InputError, Result};
 use crate::evtx_chunk::EvtxChunkData;
 use crate::evtx_file_header::EvtxFileHeader;
 use crate::evtx_record::SerializedEvtxRecord;
+use crate::evtx_structure::EvtxStructure;
+
 #[cfg(feature = "multithreading")]
 use rayon::prelude::*;
 
@@ -491,6 +493,12 @@ impl<T: ReadSeek> EvtxParser<T> {
         &mut self,
     ) -> impl Iterator<Item = Result<SerializedEvtxRecord<String>>> + '_ {
         self.serialized_records(|record| record.and_then(|record| record.into_json()))
+    }
+
+    /// Return an iterator over all the records.
+    /// Records will be instances of `EvtxStructure`
+    pub fn records_struct(&mut self) -> impl Iterator<Item = Result<EvtxStructure>> + '_ {
+      self.serialized_records(|record| record.and_then(|record| record.into_structure()))
     }
 
     /// Return an iterator over all the records.

--- a/src/evtx_parser.rs
+++ b/src/evtx_parser.rs
@@ -3,7 +3,7 @@ use crate::err::{ChunkError, EvtxError, InputError, Result};
 use crate::evtx_chunk::EvtxChunkData;
 use crate::evtx_file_header::EvtxFileHeader;
 use crate::evtx_record::SerializedEvtxRecord;
-use crate::evtx_structure::{EvtxStructureVisitor};
+use crate::evtx_structure::VisitorBuilder;
 
 #[cfg(feature = "multithreading")]
 use rayon::prelude::*;
@@ -503,7 +503,7 @@ impl<T: ReadSeek> EvtxParser<T> {
 */
     /// Return an iterator over all the records.
     /// Records will be instances of `EvtxStructure`
-    pub fn records_to_visitor<'a, 'r, R>(&'a mut self, builder: fn() -> Box<dyn EvtxStructureVisitor<VisitorResult=R>>) -> impl Iterator<Item = Result<R>> + 'a where R: Send + 'r, 'r:'a {
+    pub fn records_to_visitor<'a, 'r, C, R>(&'a mut self, builder: C) -> impl Iterator<Item = Result<R>> + 'a where R: Send + 'r, C: VisitorBuilder<R> + 'r, 'r:'a {
         self.serialized_records(move |record| record.and_then(|record| record.to_visitor(&builder)))
       }
 

--- a/src/evtx_parser.rs
+++ b/src/evtx_parser.rs
@@ -494,15 +494,9 @@ impl<T: ReadSeek> EvtxParser<T> {
     ) -> impl Iterator<Item = Result<SerializedEvtxRecord<String>>> + '_ {
         self.serialized_records(|record| record.and_then(|record| record.into_json()))
     }
-/*
+
     /// Return an iterator over all the records.
-    /// Records will be instances of `EvtxStructure`
-    pub fn records_struct(&mut self) -> impl Iterator<Item = Result<EvtxStructure>> + '_ {
-      self.serialized_records(|record| record.and_then(|record| record.into_structure()))
-    }
-*/
-    /// Return an iterator over all the records.
-    /// Records will be instances of `EvtxStructure`
+    /// Records are created by a visitor which must be created by the provided builder
     pub fn records_to_visitor<'a, 'r, C, R>(&'a mut self, builder: C) -> impl Iterator<Item = Result<R>> + 'a where R: Send + 'r, C: VisitorBuilder<R> + 'r, 'r:'a {
         self.serialized_records(move |record| record.and_then(|record| record.to_visitor(&builder)))
       }

--- a/src/evtx_parser.rs
+++ b/src/evtx_parser.rs
@@ -3,7 +3,7 @@ use crate::err::{ChunkError, EvtxError, InputError, Result};
 use crate::evtx_chunk::EvtxChunkData;
 use crate::evtx_file_header::EvtxFileHeader;
 use crate::evtx_record::SerializedEvtxRecord;
-use crate::evtx_structure::{VisitorBuilder, EvtxStructureVisitor};
+use crate::evtx_structure::EvtxStructureVisitor;
 
 #[cfg(feature = "multithreading")]
 use rayon::prelude::*;
@@ -498,7 +498,7 @@ impl<T: ReadSeek> EvtxParser<T> {
     where
         R: Send + 'r,
         V: EvtxStructureVisitor<VisitorResult=R>,
-        C: VisitorBuilder<V, R> + 'r,
+        C: Fn() -> V + Send + Sync + Clone + 'r,
         'r: 'a,
     {
         self.serialized_records(move |record| record.and_then(|record| record.to_visitor(&builder)))

--- a/src/evtx_record.rs
+++ b/src/evtx_record.rs
@@ -6,7 +6,7 @@ use crate::json_output::JsonOutput;
 use crate::model::deserialized::BinXMLDeserializedTokens;
 use crate::xml_output::{BinXmlOutput, XmlOutput};
 use crate::{EvtxChunk, ParserSettings};
-use crate::evtx_structure::{EvtxStructureVisitor, VisitorAdapter};
+use crate::evtx_structure::{VisitorAdapter, VisitorBuilder};
 
 use byteorder::ReadBytesExt;
 use chrono::prelude::*;
@@ -121,7 +121,7 @@ impl<'a> EvtxRecord<'a> {
       Ok(structure_builder.get_structure())
     }
 */
-    pub fn to_visitor<R>(self, builder: &fn() -> Box<dyn EvtxStructureVisitor<VisitorResult=R>>) -> Result<R> {
+    pub fn to_visitor<C, R>(self, builder: &C) -> Result<R> where C: VisitorBuilder<R> {
         let mut adapter = VisitorAdapter::new(builder);
         self.into_output(& mut adapter)?;
         Ok(*adapter.get_result())

--- a/src/evtx_record.rs
+++ b/src/evtx_record.rs
@@ -6,6 +6,7 @@ use crate::json_output::JsonOutput;
 use crate::model::deserialized::BinXMLDeserializedTokens;
 use crate::xml_output::{BinXmlOutput, XmlOutput};
 use crate::{EvtxChunk, ParserSettings};
+use crate::evtx_structure::{EvtxStructure, StructureBuilder};
 
 use byteorder::ReadBytesExt;
 use chrono::prelude::*;
@@ -110,6 +111,14 @@ impl<'a> EvtxRecord<'a> {
             timestamp: record_with_json_value.timestamp,
             data,
         })
+    }
+
+    /// Consume the record and parses it, producing a EvtxStrusture instance
+    pub fn into_structure(self) -> Result<EvtxStructure> {
+      let mut structure_builder = StructureBuilder::new(self.event_record_id, self.timestamp);
+      self.into_output(&mut structure_builder)?;
+
+      Ok(structure_builder.get_structure())
     }
 
     /// Consumes the record and parse it, producing an XML serialized record.

--- a/src/evtx_record.rs
+++ b/src/evtx_record.rs
@@ -11,7 +11,7 @@ use crate::evtx_structure::{VisitorAdapter, VisitorBuilder};
 use byteorder::ReadBytesExt;
 use chrono::prelude::*;
 use std::io::{Cursor, Read};
-use std::sync::{Arc};
+use std::sync::Arc;
 
 pub type RecordId = u64;
 
@@ -112,15 +112,8 @@ impl<'a> EvtxRecord<'a> {
             data,
         })
     }
-/*
-    /// Consume the record and parses it, producing a EvtxStrusture instance
-    pub fn into_structure(self) -> Result<EvtxStructure> {
-      let mut structure_builder = StructureBuilder::new(self.event_record_id, self.timestamp);
-      self.into_output(&mut structure_builder)?;
 
-      Ok(structure_builder.get_structure())
-    }
-*/
+    /// Consumes the record and returns an object of type `C`
     pub fn to_visitor<C, R>(self, builder: &C) -> Result<R> where C: VisitorBuilder<R> {
         let mut adapter = VisitorAdapter::new(builder);
         self.into_output(& mut adapter)?;

--- a/src/evtx_record.rs
+++ b/src/evtx_record.rs
@@ -6,7 +6,7 @@ use crate::json_output::JsonOutput;
 use crate::model::deserialized::BinXMLDeserializedTokens;
 use crate::xml_output::{BinXmlOutput, XmlOutput};
 use crate::{EvtxChunk, ParserSettings};
-use crate::evtx_structure::{VisitorAdapter, VisitorBuilder};
+use crate::evtx_structure::{VisitorAdapter, VisitorBuilder, EvtxStructureVisitor};
 
 use byteorder::ReadBytesExt;
 use chrono::prelude::*;
@@ -114,10 +114,10 @@ impl<'a> EvtxRecord<'a> {
     }
 
     /// Consumes the record and returns an object of type `C`
-    pub fn to_visitor<C, R>(self, builder: &C) -> Result<R> where C: VisitorBuilder<R> {
-        let mut adapter = VisitorAdapter::new(builder);
+    pub fn to_visitor<C, V, R>(self, builder: &C) -> Result<R> where C: VisitorBuilder<V, R>, V: EvtxStructureVisitor<VisitorResult=R> {
+        let mut adapter = VisitorAdapter::new(builder());
         self.into_output(& mut adapter)?;
-        Ok(*adapter.get_result())
+        Ok(adapter.get_result())
     }
 
     /// Consumes the record and parse it, producing an XML serialized record.

--- a/src/evtx_structure.rs
+++ b/src/evtx_structure.rs
@@ -109,7 +109,7 @@ impl EvtxStructure {
   pub fn time_created(&self) -> ParseResult<DateTime<Utc>> {
     let dt = self.find(&["System", "TimeCreated", "@SystemTime"])
     .expect("missing TimeCreated");
-    match NaiveDateTime::parse_from_str(dt, "%F %T.%f %Z") {
+    match NaiveDateTime::parse_from_str(dt, "%F %T%.f %Z") {
       Ok(dt) => Ok(DateTime::from_utc(dt, Utc)),
       Err(e) => Err(e)
     }

--- a/src/evtx_structure.rs
+++ b/src/evtx_structure.rs
@@ -10,14 +10,14 @@ use std::cmp::{Ord, Ordering};
 use std::collections::HashMap;
 
 #[derive(Debug)]
-pub enum EvtxXmlContentType {
+enum EvtxXmlContentType {
   Simple(String),
   Complex(Vec<EvtxXmlElement>),
   None,
 }
 
 #[derive(Debug)]
-pub struct EvtxXmlElement {
+struct EvtxXmlElement {
   pub name: String,
   pub attributes: HashMap<String, String>,
   pub content: EvtxXmlContentType,
@@ -85,14 +85,18 @@ impl EvtxStructure {
     }
   }
 
+  /// Returns the current record ID. Beware: This is *not* the event ID!
+  /// If you need the event id, call `event_id()`.
   pub fn event_record_id(&self) -> u64 {
     self.event_record_id
   }
 
+  /// Returns the timestamp of the record structure
   pub fn timestamp(&self) -> &DateTime<Utc> {
     &self.timestamp
   }
 
+  /// Returns the event id
   pub fn event_id(&self) -> u32 {
     self.find(&["System", "EventID"]).expect("missing EventID").parse().expect("invalid EventID")
   }

--- a/src/evtx_structure.rs
+++ b/src/evtx_structure.rs
@@ -6,6 +6,7 @@ use crate::xml_output::BinXmlOutput;
 use chrono::prelude::*;
 use std::borrow::Cow;
 use std::mem;
+use std::cmp::{Ord, Ordering};
 
 use std::collections::HashMap;
 
@@ -91,6 +92,25 @@ impl EvtxStructure {
 
   pub fn timestamp(&self) -> &DateTime<Utc> {
     &self.timestamp
+  }
+}
+
+impl PartialEq for EvtxStructure {
+  fn eq(&self, other: &Self) -> bool {
+    self.event_record_id() == other.event_record_id()
+  }
+}
+impl Eq for EvtxStructure {}
+
+impl Ord for EvtxStructure {
+  fn cmp(&self, other: &Self) -> Ordering {
+    self.event_record_id.cmp(&other.event_record_id)
+  }
+}
+
+impl PartialOrd for EvtxStructure {
+  fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+    Some(self.cmp(other))
   }
 }
 

--- a/src/evtx_structure.rs
+++ b/src/evtx_structure.rs
@@ -7,7 +7,6 @@ use chrono::prelude::*;
 use std::borrow::Cow;
 use std::mem;
 use std::cmp::{Ord, Ordering};
-
 use std::collections::HashMap;
 
 #[derive(Debug)]
@@ -98,6 +97,33 @@ impl EvtxStructure {
     self.find(&["System", "EventID"]).expect("missing EventID").parse().expect("invalid EventID")
   }
 
+  /// find a single value of the current event record
+  /// 
+  /// # Example
+  /// ```
+  /// # use evtx::EvtxParser;
+  /// # use std::path::PathBuf;
+  /// # pub fn samples_dir() -> PathBuf {
+  /// #  PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+  /// #  .join("samples")
+  /// #  .canonicalize()
+  /// #  .unwrap()
+  /// # }
+  /// #
+  /// # pub fn regular_sample() -> PathBuf {
+  /// # samples_dir().join("security.evtx")
+  /// # }
+  /// # let mut parser = EvtxParser::from_path(regular_sample()).unwrap();
+  /// for record_res in parser.records_struct() {
+  ///   match record_res {
+  ///     Ok(record) => {
+  ///       let event_id = record.find(&["System", "EventID"]).unwrap();
+  ///       println!("{}", event_id);
+  ///     }
+  ///     _ => eprintln!("error"),
+  ///   }
+  /// }
+  /// ```
   pub fn find(&self, path: &[&str]) -> Option<&str> {
     self.find_r(&self.content, path)
   }

--- a/src/evtx_structure.rs
+++ b/src/evtx_structure.rs
@@ -5,6 +5,12 @@ use crate::model::xml::{BinXmlPI, XmlElement};
 use crate::xml_output::BinXmlOutput;
 use std::borrow::Cow;
 
+/*
+ * Generic Parameters:
+ * V ... visitor
+ * R ... Result of visiting a single record
+ */
+
 pub trait VisitorBuilder<V: EvtxStructureVisitor<VisitorResult=R>, R>: Fn() -> V + Send + Sync + Clone {}
 
 /// Visitor object which can be used the EvtxStructure shall be printed

--- a/src/evtx_structure.rs
+++ b/src/evtx_structure.rs
@@ -64,17 +64,27 @@ impl EvtxXmlElement {
   }
 }
 
+/// Visitor object which can be used the EvtxStructure shall be printed
+pub trait EvtxStructureVisitor {
+
+  /// called on any structure element with a content type of `None`
+  fn visit_empty_element(&self, name: &str, attributes: Iter<String, String>);
+
+  /// called on any structure element which contains only a textual value
+  fn visit_simple_element(&self, name: &str, attributes: Iter<String, String>, content: &str);
+
+  /// called when a complex element (i.e. an element with child elements) starts
+  fn visit_start_element(&self, name: &str, attributes: Iter<String, String>);
+
+  /// called when a complex element (i.e. an element with child elements) ends
+  fn visit_end_element(&self, name: &str);
+}
+
+/// An object of type `EvtxStructure` represents a single event record
 pub struct EvtxStructure {
   event_record_id: u64,
   timestamp: DateTime<Utc>,
   content: EvtxXmlElement,
-}
-
-pub trait EvtxStructureVisitor {
-  fn visit_empty_element(&self, name: &str, attributes: Iter<String, String>);
-  fn visit_simple_element(&self, name: &str, attributes: Iter<String, String>, content: &str);
-  fn visit_start_element(&self, name: &str, attributes: Iter<String, String>);
-  fn visit_end_element(&self, name: &str);
 }
 
 impl EvtxStructure {
@@ -128,6 +138,8 @@ impl EvtxStructure {
     self.find(&["System", "Provider", "@Name"]).expect("missing Provider name")
   }
 
+  /// Walk through this event record to do whatever you want with the record values.
+  /// You need to implement `EvtxStructureVisitor` to use this.
   pub fn visit_structure(&self, visitor: &impl EvtxStructureVisitor) {
     self.visit_element(visitor, &self.content);
   }

--- a/src/evtx_structure.rs
+++ b/src/evtx_structure.rs
@@ -11,8 +11,6 @@ use std::borrow::Cow;
  * R ... Result of visiting a single record
  */
 
-pub trait VisitorBuilder<V: EvtxStructureVisitor<VisitorResult=R>, R>: Fn() -> V + Send + Sync + Clone {}
-
 /// Visitor object which can be used the EvtxStructure shall be printed
 pub trait EvtxStructureVisitor {
   type VisitorResult;

--- a/src/evtx_structure.rs
+++ b/src/evtx_structure.rs
@@ -1,66 +1,13 @@
 use crate::binxml::name::BinXmlName;
 use crate::binxml::value_variant::BinXmlValue;
-use crate::err::{SerializationError, SerializationResult};
-use crate::model::xml::{BinXmlPI, XmlAttribute, XmlElement};
+use crate::err::SerializationResult;
+use crate::model::xml::{BinXmlPI, XmlElement};
 use crate::xml_output::BinXmlOutput;
-use chrono::prelude::*;
-use chrono::format::ParseResult;
 use std::borrow::Cow;
-use std::mem;
-use std::cmp::{Ord, Ordering};
-use std::collections::HashMap;
+use std::marker::PhantomData;
 
-#[derive(Debug)]
-enum EvtxXmlContentType {
-  Simple(String),
-  Complex(Vec<EvtxXmlElement>),
-  None,
-}
-
-#[derive(Debug)]
-struct EvtxXmlElement {
-  pub name: String,
-  pub attributes: HashMap<String, String>,
-  pub content: EvtxXmlContentType,
-}
-
-impl EvtxXmlElement {
-  pub fn new(name: &str) -> Self {
-    Self {
-      name: name.to_owned(),
-      attributes: HashMap::new(),
-      content: EvtxXmlContentType::None,
-    }
-  }
-
-  pub fn add_attribute(&mut self, name: &str, value: &str) {
-    self.attributes.insert(name.to_owned(), value.to_owned());
-  }
-
-  pub fn add_simple_content(&mut self, value: &str) {
-    match self.content {
-      EvtxXmlContentType::None => self.content = EvtxXmlContentType::Simple(value.to_owned()),
-      EvtxXmlContentType::Simple(ref mut s) => s.push_str(value),
-      _ => {
-        if !value.is_empty() {
-          panic!(
-            "this xml element has already a value assigned: {:?}, trying to add {:?}",
-            self.content, value
-          )
-        }
-      }
-    }
-  }
-
-  pub fn add_child(&mut self, child: EvtxXmlElement) {
-    match self.content {
-      EvtxXmlContentType::Simple(_) => {
-        panic!("this xml element is a text node and cannot contain child elements")
-      }
-      EvtxXmlContentType::None => self.content = EvtxXmlContentType::Complex(vec![child]),
-      EvtxXmlContentType::Complex(ref mut v) => v.push(child),
-    }
-  }
+pub trait VisitorBuilder<R>: Send + Sync + Clone + Sized {
+  fn build(&self) -> Box<dyn EvtxStructureVisitor<VisitorResult=R>>;
 }
 
 /// Visitor object which can be used the EvtxStructure shall be printed
@@ -90,290 +37,19 @@ pub trait EvtxStructureVisitor {
   /// called when a complex element (i.e. an element with child elements) ends
   fn visit_end_element(&mut self, name: &str);
 }
-/*
-/// An object of type `EvtxStructure` represents a single event record
-pub struct EvtxStructure {
-  event_record_id: u64,
-  timestamp: DateTime<Utc>,
-  content: EvtxXmlElement,
+
+pub struct VisitorAdapter<C, R> where C: VisitorBuilder<R> {
+  target: Box<dyn EvtxStructureVisitor<VisitorResult=R>>,
+  phantom_c: PhantomData<C>,
+  phantom_r: PhantomData<R>,
 }
 
-impl EvtxStructure {
-  pub fn new(event_record_id: u64, timestamp: DateTime<Utc>) -> Self {
+impl<C, R> VisitorAdapter<C, R> where C: VisitorBuilder<R> {
+  pub fn new(builder: &C) -> Self {
     Self {
-      event_record_id,
-      timestamp,
-      content: EvtxXmlElement::new(""), // this will be overriden later
-    }
-  }
-
-  pub fn new_empty() -> Self {
-    Self {
-      event_record_id: 0,
-      timestamp: DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc),
-      content: EvtxXmlElement::new(""),
-    }
-  }
-
-  /// Returns the current record ID. Beware: This is *not* the event ID!
-  /// If you need the event id, call `event_id()`.
-  pub fn event_record_id(&self) -> u64 {
-    self.event_record_id
-  }
-
-  /// Returns the timestamp of the record structure
-  pub fn timestamp(&self) -> &DateTime<Utc> {
-    &self.timestamp
-  }
-
-  /// Returns the event id
-  pub fn event_id(&self) -> u32 {
-    self.find(&["System", "EventID"])
-    .expect("missing EventID")
-    .parse()
-    .expect("invalid EventID")
-  }
-
-  /// returns TimeCreated/@SystemTime
-  pub fn time_created(&self) -> ParseResult<DateTime<Utc>> {
-    let dt = self.find(&["System", "TimeCreated", "@SystemTime"])
-    .expect("missing TimeCreated");
-    match NaiveDateTime::parse_from_str(dt, "%F %T%.f %Z") {
-      Ok(dt) => Ok(DateTime::from_utc(dt, Utc)),
-      Err(e) => Err(e)
-    }
-  }
-
-  /// returns System/Provider/@Name
-  pub fn provider_name(&self) -> &str {
-    self.find(&["System", "Provider", "@Name"]).expect("missing Provider name")
-  }
-
-  /// Walk through this event record to do whatever you want with the record values.
-  /// You need to implement `EvtxStructureVisitor` to use this.
-  pub fn visit_structure(&self, visitor: &mut impl EvtxStructureVisitor) {
-    self.visit_element(visitor, &self.content);
-  }
-
-  fn visit_element<'a>(&'a self,
-                      visitor: &mut impl EvtxStructureVisitor,
-                      element: &'a EvtxXmlElement) {
-    let attrib_iter = element.attributes.iter().map(|(k,v)| (&k[..], &v[..]));
-    match element.content {
-      EvtxXmlContentType::None => visitor.visit_empty_element(&element.name, Box::new(attrib_iter)),
-      EvtxXmlContentType::Simple(ref s) => visitor.visit_simple_element(&element.name, Box::new(attrib_iter), s),
-      EvtxXmlContentType::Complex(ref c) => {
-        visitor.visit_start_element(&element.name, Box::new(attrib_iter));
-        for e in c.iter() {
-          self.visit_element(visitor, e);
-        }
-        visitor.visit_end_element(&element.name);
-      }
-    }
-  }
-
-  /// Find a single value of the current event record.
-  /// 
-  /// The path to the required value must be specified by using an XPath-like
-  /// syntax, but not as a single String, but as an array of path components.
-  /// For example, `/System/TimeCreated/@SystemTime` must be specified as 
-  /// `&["System", "TimeCreated", "@SystemTime"]`.
-  /// 
-  /// # Example
-  /// ```
-  /// # use evtx::EvtxParser;
-  /// # use std::path::PathBuf;
-  /// # pub fn samples_dir() -> PathBuf {
-  /// #  PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-  /// #  .join("samples")
-  /// #  .canonicalize()
-  /// #  .unwrap()
-  /// # }
-  /// #
-  /// # pub fn regular_sample() -> PathBuf {
-  /// # samples_dir().join("security.evtx")
-  /// # }
-  /// # let mut parser = EvtxParser::from_path(regular_sample()).unwrap();
-  /// for record_res in parser.records_struct() {
-  ///   match record_res {
-  ///     Ok(record) => {
-  ///       let event_id = record.find(&["System", "EventID"]).unwrap();
-  ///       let time_created = record.find(&["System", "TimeCreated", "@SystemTime"]);
-  ///       println!("{}", event_id);
-  ///     }
-  ///     _ => eprintln!("error"),
-  ///   }
-  /// }
-  /// ```
-  pub fn find(&self, path: &[&str]) -> Option<&str> {
-    self.find_r(&self.content, path)
-  }
-
-  fn find_r<'a>(&'a self, root: &'a EvtxXmlElement, path: &[&str]) -> Option<&'a str> {
-    if path.len() == 1 {
-      if path[0].chars().next().unwrap() == '@' {
-        let attribute_name = &path[0][1..];
-        match root.attributes.get(attribute_name) {
-          Some(ref v) => return Some(v),
-          None        => return None,
-        }
-      }
-    }
-
-    match root.content {
-      EvtxXmlContentType::None => panic!("invalid node type"),
-      EvtxXmlContentType::Simple(ref s) => 
-        if path.is_empty() { Some(s) } else { log::error!("path is NOT empty"); None },
-      EvtxXmlContentType::Complex(ref c) => {
-        if path.is_empty() {
-          log::error!("path IS empty");
-          None
-        } else {
-          let next_name = &path[0];
-          let remaining = &path[1..];
-          match c.iter().find(|&e| &e.name == next_name) {
-            None => { 
-              let names: Vec<&String> = c.iter().map(|r| &r.name).collect();
-              log::error!("did not find child in {:?}", names); 
-              None},
-            Some(ref next_node) => self.find_r(next_node, remaining)
-          }
-        }
-      }
-    }
-  }
-}
-
-impl PartialEq for EvtxStructure {
-  fn eq(&self, other: &Self) -> bool {
-    self.event_record_id() == other.event_record_id()
-  }
-}
-impl Eq for EvtxStructure {}
-
-impl Ord for EvtxStructure {
-  fn cmp(&self, other: &Self) -> Ordering {
-    self.event_record_id.cmp(&other.event_record_id)
-  }
-}
-
-impl PartialOrd for EvtxStructure {
-  fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-    Some(self.cmp(other))
-  }
-}
-
-pub struct StructureBuilder {
-  result: EvtxStructure,
-  node_stack: Vec<EvtxXmlElement>,
-}
-
-impl StructureBuilder {
-  pub fn new(event_record_id: u64, timestamp: DateTime<Utc>) -> Self {
-    Self {
-      result: EvtxStructure::new(event_record_id, timestamp),
-      node_stack: Vec::new(),
-    }
-  }
-
-  /// consumes self and returns the generated structure
-  pub fn get_structure(&mut self) -> EvtxStructure {
-    let mut result = EvtxStructure::new_empty();
-    mem::swap(&mut self.result, &mut result);
-    return result;
-  }
-
-  pub fn enter_named_node(&mut self, name: &str, attributes: &Vec<XmlAttribute>) {
-    let mut element = EvtxXmlElement::new(name);
-    for a in attributes {
-      element.add_attribute(a.name.as_ref().as_str(), &a.value.as_ref().as_cow_str());
-    }
-    self.node_stack.push(element);
-  }
-
-  pub fn leave_node(&mut self, _name: &str) {
-    let my_node = self.node_stack.pop().expect("stack underflow");
-    if self.node_stack.is_empty() {
-      self.result.content = my_node;
-    } else {
-      self.node_stack.last_mut().unwrap().add_child(my_node);
-    }
-  }
-}
-
-impl BinXmlOutput for StructureBuilder {
-  /// Called once when EOF is reached.
-  fn visit_end_of_stream(&mut self) -> SerializationResult<()> {
-    if !self.node_stack.is_empty() {
-      return Err(SerializationError::StructureBuilderError {
-        message: "node stack is not empty".to_owned(),
-      });
-    }
-    Ok(())
-  }
-
-  /// Called on <Tag attr="value" another_attr="value">.
-  fn visit_open_start_element(&mut self, element: &XmlElement) -> SerializationResult<()> {
-    let name = element.name.as_ref().as_str();
-
-    self.enter_named_node(name, &element.attributes);
-    Ok(())
-  }
-
-  /// Called on </Tag>, implementor may want to keep a stack to properly close tags.
-  fn visit_close_element(&mut self, element: &XmlElement) -> SerializationResult<()> {
-    let name = element.name.as_ref().as_str();
-    self.leave_node(&name);
-    Ok(())
-  }
-
-  ///
-  /// Called with value on xml text node,  (ex. <Computer>DESKTOP-0QT8017</Computer>)
-  ///                                                     ~~~~~~~~~~~~~~~
-  fn visit_characters(&mut self, value: &BinXmlValue) -> SerializationResult<()> {
-    let cow: Cow<str> = value.as_cow_str();
-    self.node_stack.last_mut().unwrap().add_simple_content(&cow);
-    Ok(())
-  }
-
-  /// Unimplemented
-  fn visit_cdata_section(&mut self) -> SerializationResult<()> {
-    Ok(())
-  }
-
-  /// Emit the character "&" and the text.
-  fn visit_entity_reference(&mut self, _: &BinXmlName) -> SerializationResult<()> {
-    Ok(())
-  }
-
-  /// Emit the characters "&" and "#" and the decimal string representation of the value.
-  fn visit_character_reference(&mut self, _: Cow<'_, str>) -> SerializationResult<()> {
-    Ok(())
-  }
-
-  /// Unimplemented
-  fn visit_processing_instruction(&mut self, _: &BinXmlPI) -> SerializationResult<()> {
-    Ok(())
-  }
-
-  /// Called once on beginning of parsing.
-  fn visit_start_of_stream(&mut self) -> SerializationResult<()> {
-    if self.node_stack.len() != 0 {
-      panic!("internal error: node stack is not empty");
-    }
-    Ok(())
-  }
-}
-*/
-
-pub struct VisitorAdapter<R> {
-  target: Box<dyn EvtxStructureVisitor<VisitorResult=R>>
-}
-
-impl<R> VisitorAdapter<R> {
-  pub fn new(builder: &fn() -> Box<dyn EvtxStructureVisitor<VisitorResult=R>>) -> Self {
-    Self {
-      target: builder()
+      target: builder.build(),
+      phantom_c: PhantomData,
+      phantom_r: PhantomData
     }
   }
 
@@ -381,7 +57,7 @@ impl<R> VisitorAdapter<R> {
     Box::new(self.target.get_result())
   }
 }
-impl<R> BinXmlOutput for VisitorAdapter<R> {
+impl<C, R> BinXmlOutput for VisitorAdapter<C, R> where C: VisitorBuilder<R> {
   /// Called once when EOF is reached.
   fn visit_end_of_stream(&mut self) -> SerializationResult<()> {
     self.target.finalize_record();

--- a/src/evtx_structure.rs
+++ b/src/evtx_structure.rs
@@ -1,0 +1,138 @@
+use crate::xml_output::BinXmlOutput;
+use crate::err::{SerializationError, SerializationResult};
+use crate::model::xml::{BinXmlPI, XmlElement};
+use crate::binxml::value_variant::BinXmlValue;
+use crate::binxml::name::BinXmlName;
+use std::borrow::Cow;
+use chrono::prelude::*;
+use std::mem;
+
+pub struct EvtxStructure {
+  event_record_id: u64,
+  timestamp: DateTime<Utc>,
+}
+
+impl EvtxStructure {
+  pub fn new(event_record_id: u64, timestamp: DateTime<Utc>) -> Self {
+    Self {
+      event_record_id,
+      timestamp
+    }
+  }
+
+  pub fn add_value(&mut self, path: &Vec<String>, value: &str) {
+
+  }
+
+  pub fn event_record_id(&self) -> u64 {
+    self.event_record_id
+  }
+
+  pub fn timestamp(&self) -> &DateTime<Utc> {
+    &self.timestamp
+  }
+
+  pub fn is_ok(&self) -> bool {
+    true
+  }
+}
+
+pub struct StructureBuilder {
+  result: Option<EvtxStructure>,
+  node_stack: Vec<String>,
+}
+
+impl StructureBuilder {
+  pub fn new(event_record_id: u64, timestamp: DateTime<Utc>) -> Self {
+    Self {
+      result: Some(EvtxStructure::new(event_record_id, timestamp)),
+      node_stack: Vec::new()
+    }
+  }
+
+  /// consumes self and returns the generated structure
+  pub fn get_structure(&mut self) -> EvtxStructure {
+    let mut result = None;
+    mem::swap(&mut self.result, &mut result);
+    return result.unwrap();
+  }
+
+  pub fn enter_named_node(&mut self, name: &str) {
+    self.node_stack.push(String::from(name));
+  }
+
+  pub fn leave_node(&mut self, _name: &str) {
+      match self.node_stack.pop() {
+          None => panic!("stack underflow"),
+          _ => ()
+      }
+  }
+
+  pub fn add_value(&mut self, value: &str) {
+    if let Some(result) = &mut self.result {
+      result.add_value(&self.node_stack, value);
+    }
+  }
+}
+
+impl BinXmlOutput for StructureBuilder {
+
+    /// Called once when EOF is reached.
+    fn visit_end_of_stream(&mut self) -> SerializationResult<()> {
+      if self.node_stack.len() != 0 {
+        return Err(SerializationError::StructureBuilderError { message: "node stack is not empty".to_owned() });
+      }
+      Ok(())
+    }
+
+    /// Called on <Tag attr="value" another_attr="value">.
+    fn visit_open_start_element(&mut self, element: &XmlElement) -> SerializationResult<()> {
+      let name = element.name.as_ref().as_str();
+      self.enter_named_node(name);
+      Ok(())
+    }
+
+    /// Called on </Tag>, implementor may want to keep a stack to properly close tags.
+    fn visit_close_element(&mut self, element: &XmlElement) -> SerializationResult<()> {
+      let name = element.name.as_ref().as_str();
+      self.leave_node(&name);
+      Ok(())
+    }
+
+    ///
+    /// Called with value on xml text node,  (ex. <Computer>DESKTOP-0QT8017</Computer>)
+    ///                                                     ~~~~~~~~~~~~~~~
+    fn visit_characters(&mut self, value: &BinXmlValue) -> SerializationResult<()> {
+      let cow: Cow<str> = value.as_cow_str();
+      self.add_value(&cow);
+      Ok(())
+    }
+
+    /// Unimplemented
+    fn visit_cdata_section(&mut self) -> SerializationResult<()> {
+      Ok(())
+    }
+
+    /// Emit the character "&" and the text.
+    fn visit_entity_reference(&mut self, entity: &BinXmlName) -> SerializationResult<()> {
+      Ok(())
+    }
+
+    /// Emit the characters "&" and "#" and the decimal string representation of the value.
+    fn visit_character_reference(&mut self, char_ref: Cow<'_, str>) -> SerializationResult<()> {
+      Ok(())
+    }
+
+    /// Unimplemented
+    fn visit_processing_instruction(&mut self, pi: &BinXmlPI) -> SerializationResult<()> {
+      Ok(())
+    }
+
+    /// Called once on beginning of parsing.
+    fn visit_start_of_stream(&mut self) -> SerializationResult<()> {
+      if self.node_stack.len() != 0 {
+        panic!("internal error: node stack is not empty");
+      }
+      Ok(())
+    }
+}

--- a/src/evtx_structure.rs
+++ b/src/evtx_structure.rs
@@ -115,6 +115,11 @@ impl EvtxStructure {
     }
   }
 
+  /// returns System/Provider/@Name
+  pub fn provider_name(&self) -> &str {
+    self.find(&["System", "Provider", "@Name"]).expect("missing Provider name")
+  }
+
   /// Find a single value of the current event record.
   /// 
   /// The path to the required value must be specified by using an XPath-like

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub use evtx_parser::{EvtxParser, IntoIterChunks, IterChunks, ParserSettings};
 pub use evtx_record::{EvtxRecord, EvtxRecordHeader, SerializedEvtxRecord};
 pub use json_output::JsonOutput;
 pub use xml_output::{BinXmlOutput, XmlOutput};
-pub use evtx_structure::{EvtxStructureVisitor};
+pub use evtx_structure::{EvtxStructureVisitor, VisitorBuilder};
 
 pub mod binxml;
 pub mod err;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub use evtx_parser::{EvtxParser, IntoIterChunks, IterChunks, ParserSettings};
 pub use evtx_record::{EvtxRecord, EvtxRecordHeader, SerializedEvtxRecord};
 pub use json_output::JsonOutput;
 pub use xml_output::{BinXmlOutput, XmlOutput};
+pub use evtx_structure::{EvtxStructure, EvtxXmlContentType, EvtxXmlElement};
 
 pub mod binxml;
 pub mod err;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub use evtx_parser::{EvtxParser, IntoIterChunks, IterChunks, ParserSettings};
 pub use evtx_record::{EvtxRecord, EvtxRecordHeader, SerializedEvtxRecord};
 pub use json_output::JsonOutput;
 pub use xml_output::{BinXmlOutput, XmlOutput};
-pub use evtx_structure::EvtxStructure;
+pub use evtx_structure::{EvtxStructure, EvtxStructureVisitor};
 
 pub mod binxml;
 pub mod err;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ mod evtx_chunk;
 mod evtx_file_header;
 mod evtx_parser;
 mod evtx_record;
+mod evtx_structure;
 mod string_cache;
 mod template_cache;
 mod utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub use evtx_parser::{EvtxParser, IntoIterChunks, IterChunks, ParserSettings};
 pub use evtx_record::{EvtxRecord, EvtxRecordHeader, SerializedEvtxRecord};
 pub use json_output::JsonOutput;
 pub use xml_output::{BinXmlOutput, XmlOutput};
-pub use evtx_structure::{EvtxStructureVisitor, VisitorBuilder};
+pub use evtx_structure::EvtxStructureVisitor;
 
 pub mod binxml;
 pub mod err;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub use evtx_parser::{EvtxParser, IntoIterChunks, IterChunks, ParserSettings};
 pub use evtx_record::{EvtxRecord, EvtxRecordHeader, SerializedEvtxRecord};
 pub use json_output::JsonOutput;
 pub use xml_output::{BinXmlOutput, XmlOutput};
-pub use evtx_structure::{EvtxStructure, EvtxXmlContentType, EvtxXmlElement};
+pub use evtx_structure::EvtxStructure;
 
 pub mod binxml;
 pub mod err;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub use evtx_parser::{EvtxParser, IntoIterChunks, IterChunks, ParserSettings};
 pub use evtx_record::{EvtxRecord, EvtxRecordHeader, SerializedEvtxRecord};
 pub use json_output::JsonOutput;
 pub use xml_output::{BinXmlOutput, XmlOutput};
-pub use evtx_structure::{EvtxStructure, EvtxStructureVisitor};
+pub use evtx_structure::{EvtxStructureVisitor};
 
 pub mod binxml;
 pub mod err;

--- a/tests/test_full_samples.rs
+++ b/tests/test_full_samples.rs
@@ -87,6 +87,7 @@ fn test_full_sample(path: impl AsRef<Path>, ok_count: usize, err_count: usize) {
       actual_ok_count, ok_count,
       "XML: Failed to parse all expected records"
     );
+    assert_eq!(actual_err_count, err_count, "XML: Expected errors");
 }
 
 #[test]

--- a/tests/test_full_samples.rs
+++ b/tests/test_full_samples.rs
@@ -68,6 +68,25 @@ fn test_full_sample(path: impl AsRef<Path>, ok_count: usize, err_count: usize) {
         "Failed to parse all records as JSON"
     );
     assert_eq!(actual_err_count, err_count, "XML: Expected errors");
+
+    let mut actual_ok_count = 0;
+    let mut actual_err_count = 0;
+
+    for r in parser.records_struct() {
+      if r.is_ok() {
+          actual_ok_count += 1;
+          if log::log_enabled!(Level::Debug) {
+              println!("error");
+          }
+      } else {
+          actual_err_count += 1;
+      }
+    }
+    
+    assert_eq!(
+      actual_ok_count, ok_count,
+      "XML: Failed to parse all expected records"
+    );
 }
 
 #[test]


### PR DESCRIPTION
A better approach then returning some general structure is to call a custom visitor while traversing an event record. This implementation provides an interface for this. One can use this to construct any structure, as needed.

Usage example:
```rust
struct MyVisitor {}
impl EvtxStructureVisitor for MyVisitor {
  type VisitorResult = Option<MySpecialEvtxDataStructure>;
  /* ... */
}
/* ... */
let records = parser.records_to_visitor(|| MyVisitor::new())
```