### PR TITLE
Do not double encode XML entity

### DIFF
--- a/samples/event_with_entity_ref.xml
+++ b/samples/event_with_entity_ref.xml
@@ -41,7 +41,7 @@
                 <HTTPRequestHeadersInfo>
                     <Header>GET /pki/crl/products/microsoftrootcert.crl HTTP/1.1</Header>
                     <Header>Accept: */*</Header>
-                    <Header>If-None-Match: &amp;quotea9ee7b1bc43d21:0&amp;quot</Header>
+                    <Header>If-None-Match: &quot;ea9ee7b1bc43d21:0&quot;</Header>
                     <Header>If-Modified-Since: Mon, 21 Nov 2016 06:01:26 GMT</Header>
                     <Header>Cache-Control: max-age = 900</Header>
                     <Header>User-Agent: Microsoft-CryptoAPI/6.1</Header>

--- a/samples/event_with_entity_ref_2.xml
+++ b/samples/event_with_entity_ref_2.xml
@@ -34,7 +34,7 @@
                 <URLCachePrefetchInfo objectType="CRYPTNET_URL_CACHE_PRE_FETCH_CRL" thisUpdateTime="2016-11-20T21:48:50Z" nextUpdateTime="2017-02-19T10:08:50Z" publishTime="2017-02-18T21:58:50Z">
                 </URLCachePrefetchInfo>
                 <URLCacheFlushInfo expireTime="2017-02-19T10:08:50Z">
-                </URLCacheFlushInfo>&amp;quot&amp;quot<URLCacheResponseInfo responseType="CRYPTNET_URL_CACHE_RESPONSE_HTTP" responseValidated="true" lastModifiedTime="2016-11-21T06:01:26Z" maxAge="900" eTag="ea9ee7b1bc43d21:0">
+                </URLCacheFlushInfo>&quot;&quot;<URLCacheResponseInfo responseType="CRYPTNET_URL_CACHE_RESPONSE_HTTP" responseValidated="true" lastModifiedTime="2016-11-21T06:01:26Z" maxAge="900" eTag="ea9ee7b1bc43d21:0">
             </URLCacheResponseInfo>
             </CacheInfo>
             <RetrievedObjects>

--- a/src/xml_output.rs
+++ b/src/xml_output.rs
@@ -122,9 +122,9 @@ impl<W: Write> BinXmlOutput for XmlOutput<W> {
     }
 
     fn visit_entity_reference(&mut self, entity: &BinXmlName) -> Result<(), SerializationError> {
-        let xml_ref = "&".to_string() + entity.as_str();
-        // This will yield stuff like `&quot`, which should be escaped.
-        let event = Event::Text(BytesText::from_plain_str(&xml_ref));
+        let xml_ref = "&".to_string() + entity.as_str() + ";";
+        // xml_ref is already escaped
+        let event = Event::Text(BytesText::from_escaped_str(&xml_ref));
         self.writer.write_event(event)?;
 
         Ok(())


### PR DESCRIPTION
XML Entity are wrongly double encoded when generating XML, the proposed fix create a valid XML entity and to not re-encode special char (&). I also fixed tests that created a malformed entity within XML value.