### PR TITLE
fix infinite recursion

### DIFF
--- a/src/binxml/deserializer.rs
+++ b/src/binxml/deserializer.rs
@@ -219,12 +219,15 @@ impl<'a> IterTokens<'a> {
                 }
                 let deserialized_token_result = self.visit_token(&mut cursor, t);
 
-                debug_assert!(
-                    cursor.position() >= offset_from_chunk_start,
-                    "Invalid state, cursor position at entering loop {}, now at {}",
-                    offset_from_chunk_start,
-                    cursor.position()
-                );
+                // omit the assert if we ran into error previously
+                if deserialized_token_result.is_ok() {
+                    debug_assert!(
+                        cursor.position() >= offset_from_chunk_start,
+                        "Invalid state, cursor position at entering loop {}, now at {}",
+                        offset_from_chunk_start,
+                        cursor.position()
+                    );
+                }
 
                 Some(deserialized_token_result)
             }


### PR DESCRIPTION
During a case, We had some issues with endless recursion (and memory consumption) with some carved evtx files. It turned out that `read_open_start_element` tends to call itself with a fixed cursor position to try to read corrupt data. However, if the resulting position still contains invalid data, this leads to an infinite recursion. 

We tried to fix this by limiting the maximum recursion depth, but this did not solve the problem. In our case, we got an endless loop in Deserializer::inner_next, where cursor remained at one position and the byte after, and back again, and so on.

The current fix is to give the heuristics exactly one try, and if this fails, the reading of the token fails. In my eyes, no more tries should be done. In addition, we restore the original cursor position (before the heuristic call), which fixes the second problem.

With our test data, the fix is working well. Unfortunately, we cannot provide the data as test data, because they contain customer data.

Regards, Jan