### PR TITLE
Fix json output when a node with attributes has the same key several times

### DIFF
--- a/tests/snapshots/test_record_samples__event_json_with_multiple_nodes_same_name.snap
+++ b/tests/snapshots/test_record_samples__event_json_with_multiple_nodes_same_name.snap
@@ -83,6 +83,11 @@ expression: "&value"
               "name": "NoProxy"
             }
           },
+          "Action_1": {
+            "#attributes": {
+              "name": "NoProxy"
+            }
+          },
           "HTTPRequestHeadersInfo": {
             "Header": "Connection: Keep-Alive",
             "Header_1": "GET /pki/crl/products/microsoftrootcert.crl HTTP/1.1",

--- a/tests/snapshots/test_record_samples__event_json_with_multiple_nodes_same_name_separate.snap
+++ b/tests/snapshots/test_record_samples__event_json_with_multiple_nodes_same_name_separate.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_record_samples.rs
-assertion_line: 276
 expression: "&value"
 ---
 {
@@ -62,6 +61,9 @@ expression: "&value"
             "_SENSAPI_NETWORK_ALIVE_LAN": "true"
           },
           "Action_attributes": {
+            "name": "NoProxy"
+          },
+          "Action_1_attributes": {
             "name": "NoProxy"
           },
           "HTTPRequestHeadersInfo": {


### PR DESCRIPTION
Some XML nodes have the same key multiple times. If the sub node have attributes, only the last key is keeped.
I adapted the code that managed nodes without attributes to manage those with.

The event "Microsoft-Windows-CertificateServicesClient-Lifecycle-System/Operational 1007" with the "EKU" node show the case.

![image](https://github.com/user-attachments/assets/6016e3a9-56fb-4535-bf02-483bdb00811a)

Before the fix
```json
{
  [...]
    "UserData": {
      "CertNotificationData": {
        "#attributes": {
          "ProcessName": "PowerShell.exe",
          "AccountName": "LAB___\\Administrator",
          "Context": "Machine"
        },
        "CertificateDetails": {
          "#attributes": {
            "Thumbprint": "a35fb0138078445b81b907997a719c2d55f070a8"
          },
          "SubjectNames": {
            "SubjectName": "www.test.local",
            "SubjectName_1": "CN=test.local",
            "SubjectName_2": "test.local"
          },
          "EKUs": {
            "EKU": {
              "#attributes": {
                "Name": "Server Authentication",
                "OID": "1.3.6.1.5.5.7.3.1"
              }
            }
          },
          "NotValidAfter": "2025-09-23T13:23:57Z"
        }
      }
    }
  }
}
```

After the fix:
``` json
 {
   [...]
    "UserData": {
      "CertNotificationData": {
        "#attributes": {
          "ProcessName": "PowerShell.exe",
          "AccountName": "LAB___\\Administrator",
          "Context": "Machine"
        },
        "CertificateDetails": {
          "#attributes": {
            "Thumbprint": "a35fb0138078445b81b907997a719c2d55f070a8"
          },
          "SubjectNames": {
            "SubjectName": "www.test.local",
            "SubjectName_1": "CN=test.local",
            "SubjectName_2": "test.local"
          },
          "EKUs": {
            "EKU": {
              "#attributes": {
                "Name": "Server Authentication",
                "OID": "1.3.6.1.5.5.7.3.1"
              }
            },
            "EKU_1": {
              "#attributes": {
                "Name": "Client Authentication",
                "OID": "1.3.6.1.5.5.7.3.2"
              }
            }
          },
          "NotValidAfter": "2025-09-23T13:23:57Z"
        }
      }
    }
  }
```