### PR TITLE
Add missing single quote in an example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Some examples
 
 `evtx_dump` can be combined with [fd](https://github.com/sharkdp/fd) for convenient batch processing of files:
   - `fd -e evtx -x evtx_dump -o jsonl` will scan a folder and dump all evtx files to a single jsonlines file.
-  - `fd -e evtx -x evtx_dump '{}' -f '{.}.xml` will create an xml file next to each evtx file, for all files in folder recursively!
+  - `fd -e evtx -x evtx_dump '{}' -f '{.}.xml'` will create an xml file next to each evtx file, for all files in folder recursively!
   - If the source of the file needs to be added to json, `xargs` (or `gxargs` on mac) and `jq` can be used: `fd -a -e evtx | xargs -I input sh -c "evtx_dump -o jsonl input | jq --arg path "input" '. + {path: \$path}'"`
   
 **Note:** by default, `evtx_dump` will try to utilize multithreading, this means that the records may be returned out of order.


### PR DESCRIPTION
Noticed the missing single quote while testing the example commands.

Thanks a lot for your work!