### PR TITLE
When validate_checksums is disabled, fix two infinite loop on buggy evtx files

### DIFF
--- a/src/string_cache.rs
+++ b/src/string_cache.rs
@@ -1,6 +1,6 @@
+use crate::ChunkOffset;
 use crate::binxml::name::{BinXmlName, BinXmlNameLink};
 use crate::err::DeserializationResult;
-use crate::ChunkOffset;
 
 use log::trace;
 use std::borrow::BorrowMut;
@@ -30,6 +30,9 @@ impl StringCache {
 
                 match link.next_string {
                     Some(offset) => {
+                        if offset == string_position {
+                            break;
+                        }
                         try_seek!(cursor_ref, offset, "next xml string")?;
                     }
                     None => break,

--- a/src/template_cache.rs
+++ b/src/template_cache.rs
@@ -1,8 +1,8 @@
 use crate::binxml::tokens::read_template_definition;
 use crate::err::DeserializationResult;
 
-use crate::model::deserialized::BinXMLTemplateDefinition;
 use crate::ChunkOffset;
+use crate::model::deserialized::BinXMLTemplateDefinition;
 
 use encoding::EncodingRef;
 use log::trace;
@@ -41,7 +41,7 @@ impl<'chunk> TemplateCache<'chunk> {
 
                 trace!("Next template will be at {}", next_template_offset);
 
-                if next_template_offset == 0 {
+                if next_template_offset == 0 || table_offset == next_template_offset {
                     break;
                 }
 


### PR DESCRIPTION
Hello,

We are using your library for digital forensic investigations, and we don't enable checksum validation in order to extract as much events as possible.

It works most of the time, but in very rare cases, we encounter buggy or corrupted EVTX files that cause our extraction process to hang indefinitely.

This pull request addresses two issues that we have encountered in production:

1. When creating the string cache for a chunk, the link to the next string can point to the current offset, resulting in an infinite loop.
2. The same can happen for the template link when creating the link.

Many thanks for your excellent library.

Best regards,
Adrien