### PR TITLE
tests: use cargo_bin! for test binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,13 +96,12 @@ checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.16"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d"
+checksum = "bcbb6924530aa9e0432442af08bbcafdad182db80d2e560da42a6d442535bf85"
 dependencies = [
  "anstyle",
  "bstr",
- "doc-comment",
  "libc",
  "predicates",
  "predicates-core",
@@ -418,12 +417,6 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ multithreading = ["rayon"]
 insta = { version = "1", features = ["json"] }
 pretty_assertions = "1.2.1"
 criterion = "0.5.1"
-assert_cmd = "2.0.4"
+assert_cmd = "2.1.1"
 predicates = "3.1"
 env_logger = "0.11.0"
 tempfile = "3.3.0"

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -15,7 +15,7 @@ fn it_respects_directory_output() {
 
     let sample = regular_sample();
 
-    let mut cmd = Command::cargo_bin("evtx_dump").expect("failed to find binary");
+    let mut cmd = Command::new(assert_cmd::cargo_bin!("evtx_dump"));
     cmd.args(["-f", &f.to_string_lossy(), sample.to_str().unwrap()]);
 
     assert!(
@@ -37,7 +37,7 @@ fn test_it_refuses_to_overwrite_directory() {
     let d = tempdir().unwrap();
 
     let sample = regular_sample();
-    let mut cmd = Command::cargo_bin("evtx_dump").expect("failed to find binary");
+    let mut cmd = Command::new(assert_cmd::cargo_bin!("evtx_dump"));
     cmd.args(["-f", &d.path().to_string_lossy(), sample.to_str().unwrap()]);
 
     cmd.assert().failure().code(1);
@@ -52,7 +52,7 @@ fn test_it_overwrites_file_anyways_if_passed_flag() {
     file.write_all(b"I'm a file!").unwrap();
 
     let sample = regular_sample();
-    let mut cmd = Command::cargo_bin("evtx_dump").expect("failed to find binary");
+    let mut cmd = Command::new(assert_cmd::cargo_bin!("evtx_dump"));
     cmd.args([
         "-f",
         &f.to_string_lossy(),

--- a/tests/test_cli_interactive.rs
+++ b/tests/test_cli_interactive.rs
@@ -10,7 +10,6 @@ mod tests {}
 mod tests {
     use super::fixtures::*;
 
-    use assert_cmd::cargo::cargo_bin;
     use rexpect::spawn;
     use std::fs::File;
     use std::io::{Read, Write};
@@ -30,7 +29,7 @@ mod tests {
 
         let cmd_string = format!(
             "{bin} -f {output_file} {sample}",
-            bin = cargo_bin("evtx_dump").display(),
+            bin = assert_cmd::cargo_bin!("evtx_dump").display(),
             output_file = f.to_string_lossy(),
             sample = sample.to_str().unwrap()
         );
@@ -65,7 +64,7 @@ mod tests {
 
         let cmd_string = format!(
             "{bin} -f {output_file} {sample}",
-            bin = cargo_bin("evtx_dump").display(),
+            bin = assert_cmd::cargo_bin!("evtx_dump").display(),
             output_file = f.to_string_lossy(),
             sample = sample.to_str().unwrap()
         );

--- a/tests/test_streaming_parity_all_samples.rs
+++ b/tests/test_streaming_parity_all_samples.rs
@@ -30,8 +30,7 @@ fn evtx_samples() -> Vec<PathBuf> {
 fn run_compare(path: &Path, extra_args: &[&str]) {
     // `compare_streaming_legacy` prints detailed mismatch context; the test harness
     // only needs to assert success/failure.
-    let mut cmd = Command::cargo_bin("compare_streaming_legacy")
-        .expect("failed to find compare_streaming_legacy binary");
+    let mut cmd = Command::new(assert_cmd::cargo_bin!("compare_streaming_legacy"));
 
     for arg in extra_args {
         cmd.arg(arg);


### PR DESCRIPTION
## Summary
- Replace deprecated `assert_cmd::cargo_bin` usage with `cargo_bin!` to avoid relying on Cargo build-dir internals.
- Bump `assert_cmd` dev-dependency to `2.1.1` to pick up the macro support.

Fixes #269.

## Test plan
- `cargo test`
- `CARGO_BUILD_BUILD_DIR=/tmp/evtx-cargo-build-dir cargo test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch tests to `assert_cmd::cargo_bin!` macro and bump `assert_cmd` dev-dependency to 2.1.1.
> 
> - **Tests**:
>   - Replace deprecated `Command::cargo_bin`/`assert_cmd::cargo::cargo_bin` with `assert_cmd::cargo_bin!` and wrap with `Command::new(...)` in `tests/test_cli.rs`, `tests/test_cli_interactive.rs`, and `tests/test_streaming_parity_all_samples.rs`.
> - **Dev Dependencies**:
>   - Bump `assert_cmd` to `2.1.1` in `Cargo.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5451ac1fcbe49679a88c74757ed72e531be43023. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->