### PR TITLE
feat: re-export RecordId from crate root

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ extern crate bitflags;
 pub use evtx_chunk::{EvtxChunk, EvtxChunkData, EvtxChunkHeader, IterChunkRecords};
 pub use evtx_file_header::{EvtxFileHeader, HeaderFlags};
 pub use evtx_parser::{EvtxParser, IntoIterChunks, IterChunks, ParserSettings};
-pub use evtx_record::{EvtxRecord, EvtxRecordHeader, SerializedEvtxRecord};
+pub use evtx_record::{EvtxRecord, EvtxRecordHeader, RecordId, SerializedEvtxRecord};
 pub use json_output::JsonOutput;
 pub use json_stream_output::JsonStreamOutput;
 pub use xml_output::{BinXmlOutput, XmlOutput};

--- a/tests/test_record_id_public.rs
+++ b/tests/test_record_id_public.rs
@@ -1,0 +1,8 @@
+use evtx::RecordId;
+
+#[test]
+fn record_id_is_public() {
+    let id: RecordId = 42;
+    assert_eq!(id, 42);
+}
+


### PR DESCRIPTION
## Summary
- Re-export `RecordId` from the crate root so downstream code can `use evtx::RecordId`.
- Add an integration test to prevent regressions.

Closes #234.

## Test plan
- [x] `cargo test -q --test test_record_id_public`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Re-exports `RecordId` at the crate root and adds an integration test to ensure it remains public.
> 
> - **Public API**:
>   - Re-export `RecordId` from `src/lib.rs` to expose `evtx::RecordId`.
> - **Tests**:
>   - Add `tests/test_record_id_public.rs` to assert `RecordId` is publicly accessible.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7b01a3c6851b4a56d9e5280e19a29536c9ded8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->