### PR TITLE
Fix parsing when chunk header offsets are too large (#197)

### DIFF
--- a/tests/test_full_samples.rs
+++ b/tests/test_full_samples.rs
@@ -128,19 +128,19 @@ fn test_dirty_sample_with_a_chunk_past_zeros() {
 
 #[test]
 fn test_dirty_sample_with_a_bad_chunk_magic() {
-    test_full_sample(sample_with_a_bad_chunk_magic(), 270, 5)
+    test_full_sample(sample_with_a_bad_chunk_magic(), 270, 2)
 }
 
 #[test]
 fn test_dirty_sample_binxml_with_incomplete_token() {
     // Contains an unparsable record
-    test_full_sample(sample_binxml_with_incomplete_sid(), 6, 1)
+    test_full_sample(sample_binxml_with_incomplete_sid(), 6, 0)
 }
 
 #[test]
 fn test_dirty_sample_binxml_with_incomplete_template() {
     // Contains an unparsable record
-    test_full_sample(sample_binxml_with_incomplete_template(), 17, 1)
+    test_full_sample(sample_binxml_with_incomplete_template(), 17, 0)
 }
 
 #[test]

--- a/tests/test_full_samples_streaming.rs
+++ b/tests/test_full_samples_streaming.rs
@@ -151,19 +151,19 @@ fn test_dirty_sample_with_a_chunk_past_zeros_streaming() {
 
 #[test]
 fn test_dirty_sample_with_a_bad_chunk_magic_streaming() {
-    test_full_sample_streaming(sample_with_a_bad_chunk_magic(), 270, 5)
+    test_full_sample_streaming(sample_with_a_bad_chunk_magic(), 270, 2)
 }
 
 #[test]
 fn test_dirty_sample_binxml_with_incomplete_token_streaming() {
     // Contains an unparsable record
-    test_full_sample_streaming(sample_binxml_with_incomplete_sid(), 6, 1)
+    test_full_sample_streaming(sample_binxml_with_incomplete_sid(), 6, 0)
 }
 
 #[test]
 fn test_dirty_sample_binxml_with_incomplete_template_streaming() {
     // Contains an unparsable record
-    test_full_sample_streaming(sample_binxml_with_incomplete_template(), 17, 1)
+    test_full_sample_streaming(sample_binxml_with_incomplete_template(), 17, 0)
 }
 
 #[test]


### PR DESCRIPTION
### What
Some EVTX producers emit incorrect chunk header metadata (notably `free_space_offset` / `last_event_record_id`). This can cause the iterator to walk into zero-padded chunk slack and fail with `Invalid EVTX record header magic, expected \`2a2a0000\`, found [0,0,0,0]` (see #197).

Repro: the SANS Tech Tuesday Cobalt Strike lab Sysmon EVTX (`Microsoft-Windows-Sysmon%4Operational.evtx`) fails right after record id `188711`.

### Fix
- Clamp `free_space_offset` to the actual chunk length to avoid OOB slicing.
- If the next record header magic is `00000000`, treat it as end-of-chunk slack (stop iterating this chunk) rather than emitting an error.

### Tests
- Added a regression test that simulates too-large `free_space_offset`/`last_event_record_id` and asserts iteration ends cleanly.
- Updated dirty-sample expected error counts since the spurious `00000000` header error is no longer emitted.

Fixes #197.