### PR TITLE
pub Timestamp Offset

### DIFF
--- a/src/evtx_record.rs
+++ b/src/evtx_record.rs
@@ -7,7 +7,9 @@ use crate::utils::bytes;
 use crate::utils::windows::filetime_to_timestamp;
 use crate::{EvtxChunk, ParserSettings};
 
-use jiff::Timestamp;
+pub use jiff::Timestamp;
+#[allow(unused)]
+pub use jiff::tz::Offset;
 use std::io::Cursor;
 use std::sync::Arc;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ extern crate bitflags;
 pub use evtx_chunk::{EvtxChunk, EvtxChunkData, EvtxChunkHeader, IterChunkRecords};
 pub use evtx_file_header::{EvtxFileHeader, HeaderFlags};
 pub use evtx_parser::{EvtxParser, IntoIterChunks, IterChunks, ParserSettings};
-pub use evtx_record::{EvtxRecord, EvtxRecordHeader, RecordId, SerializedEvtxRecord};
+pub use evtx_record::{EvtxRecord, EvtxRecordHeader, Offset, RecordId, SerializedEvtxRecord, Timestamp};
 pub use utils::utf16::{Utf16LeDecodeError, Utf16LeSlice};
 
 pub mod binxml;


### PR DESCRIPTION
redeclare `jiff::Timestamp` and `jiff::tz::Offset` so users of `evtx` can also declare instances of these types.

I need this so I can upgrade my use of `evtx` in my project https://github.com/jtmoon79/super-speedy-syslog-searcher/blob/main/Cargo.toml#L68