### PR TITLE
[FIX] Prevent infinite loop parsing when record has a corrupted size

### DIFF
--- a/src/evtx_chunk.rs
+++ b/src/evtx_chunk.rs
@@ -341,6 +341,7 @@ impl<'a> Iterator for IterChunkRecords<'a> {
         let binxml_start = record_start + EVTX_RECORD_HEADER_SIZE as u64;
         let binxml_end = binxml_start.saturating_add(binxml_data_size as u64);
         if binxml_end as usize > self.chunk.data.len() {
+            self.exhausted = true;
             return Some(Err(EvtxError::FailedToParseRecord {
                 record_id: record_header.event_record_id,
                 source: Box::new(EvtxError::FailedToCreateRecordModel(


### PR DESCRIPTION
Hi,

I've encountered an issue with evtx records that have a corrupted data_size field. This causes an infinite loop.

I can't provide the evtx records, but here is the debug output:

```
09:47:09 [INFO] Record id - 0
09:47:09 [DEBUG] (14) evtx::evtx_chunk: Record header - EvtxRecordHeader { data_size: 3099113656, event_record_id: 0, timestamp: 1601-01-01T00:00:00Z }
09:47:09 [INFO] Record id - 0
09:47:09 [DEBUG] (14) evtx::evtx_chunk: Record header - EvtxRecordHeader { data_size: 3099113656, event_record_id: 0, timestamp: 1601-01-01T00:00:00Z }
09:47:09 [INFO] Record id - 0
09:47:09 [DEBUG] (14) evtx::evtx_chunk: Record header - EvtxRecordHeader { data_size: 3099113656, event_record_id: 0, timestamp: 1601-01-01T00:00:00Z }
09:47:09 [INFO] Record id - 0
``` 

The fix allows skipping the chunk and exiting the infinite loop.

Thanks in advance :)